### PR TITLE
Network Capture Skeleton

### DIFF
--- a/Sources/BlueTriangle/BlueTriangle.swift
+++ b/Sources/BlueTriangle/BlueTriangle.swift
@@ -74,6 +74,10 @@ final public class BlueTriangleConfiguration: NSObject {
     /// smallest allowed interval (one measurement every 1/60 of a second).
     @objc public var performanceMonitorSampleRate: TimeInterval = 1
 
+    /// Percentage of sessions for which network calls will be captured. A value of `0.05`
+    /// means that 5% of sessions will be tracked.
+    @objc public var networkSampleRate: Double = 0.05
+
     var makeLogger: () -> Logging = {
         BTLogger.live
     }
@@ -144,6 +148,10 @@ final public class BlueTriangle: NSObject {
             logger: logger,
             performanceMonitorFactory: configuration.makePerformanceMonitorFactory())
     }()
+
+    private static var shouldCaptureRequests: Bool {
+        .random(probability: configuration.networkSampleRate)
+    }
 
     public private(set) static var initialized = false
 

--- a/Sources/BlueTriangle/BlueTriangle.swift
+++ b/Sources/BlueTriangle/BlueTriangle.swift
@@ -157,6 +157,8 @@ final public class BlueTriangle: NSObject {
 
     private static var crashReportManager: CrashReportManaging?
 
+    private static var capturedRequestCollector: CapturedRequestCollecting?
+
     private static var appEventObserver: AppEventObserver?
 
     /// Blue Triangle Technologies-assigned site ID.
@@ -273,6 +275,7 @@ final public class BlueTriangle: NSObject {
         lock.lock()
         precondition(initialized, "BlueTriangle must be initialized before sending timers.")
         let timer = timerFactory(page)
+        // If network capture is enabled, also pass this to network capture thing
         lock.unlock()
         return timer
     }
@@ -299,6 +302,29 @@ final public class BlueTriangle: NSObject {
             return
         }
         uploader.send(request: request)
+    }
+}
+
+// MARK: - Network Capture
+extension BlueTriangle {
+    @usableFromInline
+    static func startInternalTimer() -> InternalTimer? {
+        // TODO: do we still need to use sync?
+        guard shouldCaptureRequests else {
+            return nil
+        }
+        // TODO: use builder
+        var timer = InternalTimer(logger: logger,
+                                  intervalProvider: configuration.timerConfiguration.timeIntervalProvider)
+        timer.start()
+        return timer
+    }
+
+    static func sendTimer(_ timer: InternalTimer) {
+        guard shouldCaptureRequests else {
+            return
+        }
+        // ...
     }
 }
 

--- a/Sources/BlueTriangle/BlueTriangle.swift
+++ b/Sources/BlueTriangle/BlueTriangle.swift
@@ -308,19 +308,18 @@ final public class BlueTriangle: NSObject {
 // MARK: - Network Capture
 extension BlueTriangle {
     @usableFromInline
-    static func startInternalTimer() -> InternalTimer? {
-        // TODO: do we still need to use sync?
+    static func startRequestTimer() -> InternalTimer? {
         guard shouldCaptureRequests else {
             return nil
         }
-        // TODO: use builder
         var timer = InternalTimer(logger: logger,
                                   intervalProvider: configuration.timerConfiguration.timeIntervalProvider)
         timer.start()
         return timer
     }
 
-    static func sendTimer(_ timer: InternalTimer) {
+    @usableFromInline
+    static func captureRequest(timer: InternalTimer, data: Data?, response: URLResponse?) {
         guard shouldCaptureRequests else {
             return
         }
@@ -328,6 +327,7 @@ extension BlueTriangle {
     }
 }
 
+// MARK: - Crash Reporting
 extension BlueTriangle {
     static func configureCrashTracking(with crashConfiguration: CrashReportConfiguration) {
         crashReportManager = CrashReportManager(crashConfiguration,

--- a/Sources/BlueTriangle/BlueTriangle.swift
+++ b/Sources/BlueTriangle/BlueTriangle.swift
@@ -323,7 +323,7 @@ extension BlueTriangle {
         guard shouldCaptureRequests else {
             return
         }
-        // ...
+        capturedRequestCollector?.collect(timer: timer, data: data, response: response)
     }
 }
 

--- a/Sources/BlueTriangle/Constants.swift
+++ b/Sources/BlueTriangle/Constants.swift
@@ -11,6 +11,7 @@ enum Constants {
     static let browserName = "Native App"
     static let globalUserIDKey = "com.bluetriangle.kGlobalUserIDUserDefault"
     static let timerEndpoint: URL = "https://d.btttag.com/analytics.rcv"
+    static let capturedRequestEndpoint: URL = "https://d.btttag.com/wcdv02.rcv"
     static let errorEndpoint: URL = "https://d.btttag.com/err.rcv"
 
     static let minimumSampleInterval: TimeInterval = 1/60

--- a/Sources/BlueTriangle/Extensions/Bool+Utils.swift
+++ b/Sources/BlueTriangle/Extensions/Bool+Utils.swift
@@ -8,6 +8,10 @@
 import Foundation
 
 extension Bool {
+    var smallIntString: String {
+        self ? "1" : "0"
+    }
+
     static func random(probability: Double) -> Self {
         guard probability <= 1.0 else {
             return true

--- a/Sources/BlueTriangle/Extensions/Bool+Utils.swift
+++ b/Sources/BlueTriangle/Extensions/Bool+Utils.swift
@@ -1,0 +1,17 @@
+//
+//  Bool+Utils.swift
+//
+//  Created by Mathew Gacy on 2/17/22.
+//  Copyright © 2022 Blue Triangle. All rights reserved.
+//
+
+import Foundation
+
+extension Bool {
+    static func random(probability: Double) -> Self {
+        guard probability <= 1.0 else {
+            return true
+        }
+        return Double.random(in: 0...1) <= probability
+    }
+}

--- a/Sources/BlueTriangle/Extensions/URLSession+NetworkCapture.swift
+++ b/Sources/BlueTriangle/Extensions/URLSession+NetworkCapture.swift
@@ -1,0 +1,28 @@
+//
+//  URLSession+NetworkCapture.swift
+//
+//  Created by Mathew Gacy on 2/22/22.
+//  Copyright © 2022 Blue Triangle. All rights reserved.
+//
+
+import Foundation
+
+// MARK: - Adding Data Tasks to a Session
+public extension URLSession {
+    @discardableResult
+    @inlinable
+    func btDataTask(
+        with url: URL,
+        completionHandler: @escaping (Data?, URLResponse?, Error?) -> Void
+    ) -> URLSessionDataTask {
+        let timer = BlueTriangle.startRequestTimer()
+        return dataTask(with: url) { data, response, error in
+            if var timer = timer {
+                timer.end()
+                BlueTriangle.captureRequest(timer: timer, data: data, response: response)
+            }
+
+            completionHandler(data, response, error)
+        }
+    }
+}

--- a/Sources/BlueTriangle/InternalTimer.swift
+++ b/Sources/BlueTriangle/InternalTimer.swift
@@ -1,0 +1,63 @@
+//
+//  InternalTimer.swift
+//
+//  Created by Mathew Gacy on 2/20/22.
+//  Copyright © 2022 Blue Triangle. All rights reserved.
+//
+
+import Foundation
+
+@usableFromInline
+struct InternalTimer {
+
+    enum State: Int {
+        case initial
+        case started
+        case ended
+    }
+
+    enum Action {
+        case start
+        case end
+    }
+
+    private let timeIntervalProvider: () -> TimeInterval
+    private let logger: Logging
+
+    private(set) var state: State = .initial
+    private(set) var startTime: TimeInterval = 0.0
+    private(set) var endTime: TimeInterval = 0.0
+
+    init(logger: Logging,
+         intervalProvider: @escaping () -> TimeInterval = { Date().timeIntervalSince1970 }
+    ) {
+        self.logger = logger
+        self.timeIntervalProvider = intervalProvider
+    }
+
+    mutating func start() {
+        handle(.start)
+    }
+
+    @usableFromInline
+    mutating func end() {
+        handle(.end)
+    }
+
+    private mutating func handle(_ action: Action) {
+        switch (state, action) {
+        case (.initial, .start):
+            startTime = timeIntervalProvider()
+            state = .started
+        case (.started, .end):
+            endTime = timeIntervalProvider()
+            state = .ended
+        case (.initial, .end):
+            logger.error("Cannot end timer before it is started.")
+        case (.started, .start):
+            logger.error("Start time already set.")
+        case (.ended, .start), (.ended, .end):
+            logger.error("Timer already ended.")
+        }
+    }
+}

--- a/Sources/BlueTriangle/Models/CapturedRequest.swift
+++ b/Sources/BlueTriangle/Models/CapturedRequest.swift
@@ -1,0 +1,78 @@
+//
+//  CapturedRequest.swift
+//
+//  Created by Mathew Gacy on 2/20/22.
+//  Copyright © 2022 Blue Triangle. All rights reserved.
+//
+
+import Foundation
+
+struct CapturedRequest: Encodable {
+    enum InitiatorType: String {
+        /// CSS
+        case css
+        /// HTML
+        case html
+        /// IFrame
+        case iFrame = "iframe"
+        /// Image
+        case image = "img"
+        /// Link
+        case link
+        /// Other
+        case other
+        /// Javascript
+        case script
+        /// XMLHttpRequest
+        case xmlHttpRequest = "xmlhttprequest"
+
+        init(pathExtension: String) {
+            switch pathExtension {
+            case "css":
+                self = .css
+            case "jpeg", "jpg", "png", "tif", "tiff":
+                self = .image
+            case "js":
+                self = .script
+            case "xml":
+                self = .xmlHttpRequest
+            default:
+                return .other
+            }
+        }
+    }
+
+    let entryType = "resource"
+    /// Page domain without host.
+    var domain: String
+    /// Subdomain of the fully qualified domain name.
+    var host: String
+    /// Full URL.
+    var url: String
+    /// Name of the file.
+    var file: String?
+    /// Reuest start time.
+    var startTime: Millisecond
+    /// Request duration.
+    var duration: Millisecond
+    /// The type of field being returned.
+    var initiatorType: InitiatorType
+    /// Compressed size of content.
+    var decodedBodySize: Int
+    /// Decompressed size of content.
+    var encodedBodySize: Int
+}
+
+// MARK: - Supporting Types
+extension CapturedRequest {
+    enum CodingKeys: String, CodingKey {
+        case entryType = "e"
+        case domain = "dmn"
+        case file = "f"
+        case duration = "d"
+        case initiatorType = "i"
+        case host = "h"
+        case decodedBodySize = "dz"
+        case encodedBodySize = "Ez"
+    }
+}

--- a/Sources/BlueTriangle/Models/CapturedRequest.swift
+++ b/Sources/BlueTriangle/Models/CapturedRequest.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 struct CapturedRequest: Encodable {
-    enum InitiatorType: String {
+    enum InitiatorType: String, Encodable {
         /// CSS
         case css
         /// HTML
@@ -26,6 +26,7 @@ struct CapturedRequest: Encodable {
         /// XMLHttpRequest
         case xmlHttpRequest = "xmlhttprequest"
 
+        // TODO: complete / expand
         init(pathExtension: String) {
             switch pathExtension {
             case "css":
@@ -37,7 +38,7 @@ struct CapturedRequest: Encodable {
             case "xml":
                 self = .xmlHttpRequest
             default:
-                return .other
+                self = .other
             }
         }
     }

--- a/Sources/BlueTriangle/NetworkCapture/CapturedRequestBuilder.swift
+++ b/Sources/BlueTriangle/NetworkCapture/CapturedRequestBuilder.swift
@@ -1,0 +1,55 @@
+//
+//  CapturedRequestBuilder.swift
+//
+//  Created by Mathew Gacy on 2/22/22.
+//  Copyright © 2022 Blue Triangle. All rights reserved.
+//
+
+import Foundation
+
+struct CapturedRequestBuilder {
+    let build: (Session, Page, PageTimeInterval, [CapturedRequest]) throws -> Request
+
+    static func makeParameters(
+        siteID: String,
+        sessionID: String,
+        trafficSegment: String,
+        isNewUser: Bool,
+        pageType: String,
+        pageName: String,
+        startTime: Millisecond,
+        pageTime: Millisecond
+    ) -> Request.Parameters {
+        [
+            "siteID": siteID,
+            "nStart": String(startTime),
+            "pageName": pageName,
+            "txnName": trafficSegment,
+            "sessionID": String(sessionID),
+            "WCDtt": "c",
+            "pgTm": String(pageTime),
+            "NVSTR": isNewUser.smallIntString,
+            "pageType": pageType
+        ]
+    }
+
+    static var live: Self = CapturedRequestBuilder { session, page, interval, model in
+        // TOOD: handle `isNewUser`; ask Joel if it should be part of `Session`
+        let isNewUser = false
+
+        let parameters = makeParameters(
+            siteID: session.siteID,
+            sessionID: String(session.sessionID),
+            trafficSegment: session.trafficSegmentName,
+            isNewUser: isNewUser,
+            pageType: page.pageType,
+            pageName: page.pageName,
+            startTime: interval.startTime,
+            pageTime: interval.pageTime)
+
+        return try Request(method: .post,
+                           url: Constants.capturedRequestEndpoint,
+                           parameters: parameters,
+                           model: model)
+    }
+}

--- a/Sources/BlueTriangle/NetworkCapture/CapturedRequestCollector.swift
+++ b/Sources/BlueTriangle/NetworkCapture/CapturedRequestCollector.swift
@@ -1,0 +1,22 @@
+//
+//  CapturedRequestCollector.swift
+//
+//  Created by Mathew Gacy on 2/20/22.
+//  Copyright © 2022 Blue Triangle. All rights reserved.
+//
+
+import Foundation
+
+final class CapturedRequestCollector: CapturedRequestCollecting {
+    private let logger: Logging
+    private let uploader: Uploading
+
+    init(logger: Logging, uploader: Uploading) {
+        self.logger = logger
+        self.uploader = uploader
+    }
+
+    func collect(timer: InternalTimer, data: Data?, response: URLResponse?) {
+        // ...
+    }
+}

--- a/Sources/BlueTriangle/NetworkCapture/CapturedRequestCollector.swift
+++ b/Sources/BlueTriangle/NetworkCapture/CapturedRequestCollector.swift
@@ -9,14 +9,22 @@ import Foundation
 
 final class CapturedRequestCollector: CapturedRequestCollecting {
     private let logger: Logging
+    private let requestBuilder: CapturedRequestBuilder
     private let uploader: Uploading
+    private var requests: [CapturedRequest] = []
 
-    init(logger: Logging, uploader: Uploading) {
+    init(logger: Logging, requestBuilder: CapturedRequestBuilder, uploader: Uploading) {
         self.logger = logger
+        self.requestBuilder = requestBuilder
         self.uploader = uploader
     }
 
     func collect(timer: InternalTimer, data: Data?, response: URLResponse?) {
         // ...
+    }
+
+    func uploadCapturedRequests(session: Session, page: Page, pageTimeInterval: PageTimeInterval)throws {
+        let request = try requestBuilder.build(session, page, pageTimeInterval, requests)
+        uploader.send(request: request)
     }
 }

--- a/Sources/BlueTriangle/Protocols/CapturedRequestCollecting.swift
+++ b/Sources/BlueTriangle/Protocols/CapturedRequestCollecting.swift
@@ -1,0 +1,12 @@
+//
+//  CapturedRequestCollecting.swift
+//
+//  Created by Mathew Gacy on 2/20/22.
+//  Copyright © 2022 Blue Triangle. All rights reserved.
+//
+
+import Foundation
+
+protocol CapturedRequestCollecting {
+    // TODO: add implementation
+}

--- a/Sources/BlueTriangle/Protocols/CapturedRequestCollecting.swift
+++ b/Sources/BlueTriangle/Protocols/CapturedRequestCollecting.swift
@@ -8,5 +8,5 @@
 import Foundation
 
 protocol CapturedRequestCollecting {
-    // TODO: add implementation
+    func collect(timer: InternalTimer, data: Data?, response: URLResponse?)
 }


### PR DESCRIPTION
- Model for request to network capture endpoint (`CapturedRequest`)
- Builder for above request (`CapturedRequestBuilder`)
- Protocol and initial basic implementation of object responsible for handling network capture (`CapturedRequestCollector`)
- First `URLSession` extension method demonstrating how requests will be captured (`btDataTask(with:completionHandler:)`)