### PR TITLE
Manager for Capture Request Timer

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,0 +1,16 @@
+{
+  "object": {
+    "pins": [
+      {
+        "package": "swift-collections",
+        "repositoryURL": "https://github.com/apple/swift-collections.git",
+        "state": {
+          "branch": null,
+          "revision": "48254824bb4248676bf7ce56014ff57b142b77eb",
+          "version": "1.0.2"
+        }
+      }
+    ]
+  },
+  "version": 1
+}

--- a/Package.swift
+++ b/Package.swift
@@ -14,10 +14,18 @@ let package = Package(
             name: "BlueTriangle",
             targets: ["BlueTriangle"])
     ],
+    dependencies: [
+      .package(
+        url: "https://github.com/apple/swift-collections.git",
+        .upToNextMajor(from: "1.0.0")
+      )
+    ],
     targets: [
         .target(
             name: "BlueTriangle",
-            dependencies: []),
+            dependencies: [
+              .product(name: "Collections", package: "swift-collections")
+            ]),
         .testTarget(
             name: "BlueTriangleTests",
             dependencies: ["BlueTriangle"]),

--- a/Sources/BlueTriangle/Models/CapturedRequest.swift
+++ b/Sources/BlueTriangle/Models/CapturedRequest.swift
@@ -7,8 +7,8 @@
 
 import Foundation
 
-struct CapturedRequest: Encodable {
-    enum InitiatorType: String, Encodable {
+struct CapturedRequest: Encodable, Equatable {
+    enum InitiatorType: String, Encodable, Equatable {
         /// CSS
         case css
         /// HTML

--- a/Sources/BlueTriangle/NetworkCapture/CaptureTimerManager.swift
+++ b/Sources/BlueTriangle/NetworkCapture/CaptureTimerManager.swift
@@ -89,9 +89,6 @@ final class CaptureTimerManager: CaptureTimerManaging {
                 state = .inactive
             }
         case (.inactive, .fire):
-            #if DEBUG
-            print("\(#function) - Unanticipated timer fire.")
-            #endif
             timer?.cancel()
             timer = nil
         case (.inactive, .pause):

--- a/Sources/BlueTriangle/NetworkCapture/CaptureTimerManager.swift
+++ b/Sources/BlueTriangle/NetworkCapture/CaptureTimerManager.swift
@@ -54,8 +54,8 @@ final class CaptureTimerManager: CaptureTimerManaging {
     }
 }
 
-private extension CaptureTimerManager {
-    func makeTimer(delay: TimeInterval) -> DispatchSourceTimer {
+ extension CaptureTimerManager {
+    private func makeTimer(delay: TimeInterval) -> DispatchSourceTimer {
         let timer = DispatchSource.makeTimerSource(flags: timerFlags, queue: queue)
         timer.schedule(deadline: .now() + delay, leeway: timerLeeway)
         timer.setEventHandler { [weak self] in
@@ -64,7 +64,7 @@ private extension CaptureTimerManager {
         return timer
     }
 
-    func handle(_ action: Action) {
+    private func handle(_ action: Action) {
         switch (state, action) {
         case (.inactive, .start):
             timer = makeTimer(delay: configuration.initialSpanDuration)

--- a/Sources/BlueTriangle/NetworkCapture/CaptureTimerManager.swift
+++ b/Sources/BlueTriangle/NetworkCapture/CaptureTimerManager.swift
@@ -1,0 +1,111 @@
+//
+//  CaptureTimerManager.swift
+//
+//  Created by Mathew Gacy on 3/3/22.
+//  Copyright © 2022 Blue Triangle. All rights reserved.
+//
+
+import Foundation
+
+final class CaptureTimerManager: CaptureTimerManaging {
+    enum State {
+        case inactive
+        case active(span: Int)
+
+        var span: Int {
+            switch self {
+            case .inactive:
+                return 0
+            case .active(let span):
+                return span
+            }
+        }
+    }
+
+    enum Action {
+        case start
+        case pause
+        case fire
+    }
+
+    private let timerFlags: DispatchSource.TimerFlags = []
+    private let leeway: DispatchTimeInterval = .seconds(1)
+    private let queue: DispatchQueue
+    private let configuration: NetworkCaptureConfiguration
+    private var timer: DispatchSourceTimer?
+    private var state: State = .inactive
+    var handler: () -> Void
+
+    init(
+        queue: DispatchQueue,
+        configuration: NetworkCaptureConfiguration,
+        handler: @escaping () -> Void = { }
+    ) {
+        self.queue = queue
+        self.configuration = configuration
+        self.handler = handler
+    }
+
+    deinit {
+        if case .active = state {
+            timer?.cancel()
+        }
+    }
+
+    func start() {
+        handle(.start)
+    }
+
+    func cancel() {
+        handle(.pause)
+    }
+}
+
+private extension CaptureTimerManager {
+    func makeTimer(delay: TimeInterval) -> DispatchSourceTimer {
+        let timer = DispatchSource.makeTimerSource(flags: timerFlags, queue: queue)
+        timer.schedule(deadline: .now() + delay, leeway: leeway)
+        timer.setEventHandler { [weak self] in
+            self?.handle(.fire)
+        }
+        return timer
+    }
+
+    func handle(_ action: Action) {
+        switch (state, action) {
+        case (.inactive, .start):
+            timer = makeTimer(delay: configuration.initialSpanDuration)
+            timer?.activate()
+            state = .active(span: 1)
+        case (.active, .start):
+            timer?.cancel()
+            timer = makeTimer(delay: configuration.initialSpanDuration)
+            timer?.activate()
+            state = .active(span: 1)
+        case (.active(let span), .fire):
+            handler()
+            let nextSpan = span + 1
+            if nextSpan <= configuration.spanCount {
+                timer = makeTimer(delay: configuration.subsequentSpanDuration)
+                timer?.activate()
+                state = .active(span: nextSpan)
+            } else {
+                // Timer should not be active, but cancel to be safe.
+                timer?.cancel()
+                timer = nil
+                state = .inactive
+            }
+        case (.inactive, .fire):
+            #if DEBUG
+            print("\(#function) - Unanticipated timer fire.")
+            #endif
+            timer?.cancel()
+            timer = nil
+        case (.inactive, .pause):
+            return
+        case (.active, .pause):
+            timer?.cancel()
+            timer = nil
+        }
+    }
+}

--- a/Sources/BlueTriangle/NetworkCapture/CaptureTimerManager.swift
+++ b/Sources/BlueTriangle/NetworkCapture/CaptureTimerManager.swift
@@ -11,18 +11,9 @@ final class CaptureTimerManager: CaptureTimerManaging {
     enum State: Equatable {
         case inactive
         case active(span: Int)
-
-        var span: Int {
-            switch self {
-            case .inactive:
-                return 0
-            case .active(let span):
-                return span
-            }
-        }
     }
 
-    enum Action {
+    private enum Action {
         case start
         case pause
         case fire

--- a/Sources/BlueTriangle/NetworkCapture/CaptureTimerManager.swift
+++ b/Sources/BlueTriangle/NetworkCapture/CaptureTimerManager.swift
@@ -108,6 +108,7 @@ private extension CaptureTimerManager {
         case (.active, .pause):
             timer?.cancel()
             timer = nil
+            state = .inactive
         }
     }
 }

--- a/Sources/BlueTriangle/NetworkCapture/CapturedRequestCollector.swift
+++ b/Sources/BlueTriangle/NetworkCapture/CapturedRequestCollector.swift
@@ -22,6 +22,7 @@ final class CapturedRequestCollector: CapturedRequestCollecting {
         requestBuilder: CapturedRequestBuilder,
         uploader: Uploading
     ) {
+        self.queue = queue
         self.logger = logger
         self.timerManager = timerManager
         self.requestBuilder = requestBuilder

--- a/Sources/BlueTriangle/NetworkCapture/CapturedRequestCollector.swift
+++ b/Sources/BlueTriangle/NetworkCapture/CapturedRequestCollector.swift
@@ -8,12 +8,12 @@
 import Foundation
 
 final class CapturedRequestCollector: CapturedRequestCollecting {
+    private var storage = Timeline<RequestSpan>()
     private let queue: DispatchQueue
     private let logger: Logging
     private var timerManager: CaptureTimerManaging
     private let requestBuilder: CapturedRequestBuilder
     private let uploader: Uploading
-    private var requests: [CapturedRequest] = []
 
     init(
         queue: DispatchQueue,

--- a/Sources/BlueTriangle/NetworkCapture/CapturedRequestCollector.swift
+++ b/Sources/BlueTriangle/NetworkCapture/CapturedRequestCollector.swift
@@ -8,18 +8,39 @@
 import Foundation
 
 final class CapturedRequestCollector: CapturedRequestCollecting {
+    private let queue: DispatchQueue
     private let logger: Logging
+    private var timerManager: CaptureTimerManaging
     private let requestBuilder: CapturedRequestBuilder
     private let uploader: Uploading
     private var requests: [CapturedRequest] = []
 
-    init(logger: Logging, requestBuilder: CapturedRequestBuilder, uploader: Uploading) {
+    init(
+        queue: DispatchQueue,
+        logger: Logging,
+        timerManager: CaptureTimerManaging,
+        requestBuilder: CapturedRequestBuilder,
+        uploader: Uploading
+    ) {
         self.logger = logger
+        self.timerManager = timerManager
         self.requestBuilder = requestBuilder
         self.uploader = uploader
+        self.timerManager.handler = { [weak self] in
+            self?.timerFired()
+        }
+    }
+
+    func start(page: Page) {
+        timerManager.start()
+        // ...
     }
 
     func collect(timer: InternalTimer, data: Data?, response: URLResponse?) {
+        // ...
+    }
+
+    func timerFired() {
         // ...
     }
 

--- a/Sources/BlueTriangle/NetworkCapture/NetworkCaptureConfiguration.swift
+++ b/Sources/BlueTriangle/NetworkCapture/NetworkCaptureConfiguration.swift
@@ -7,9 +7,15 @@
 
 import Foundation
 
+/// Configuration for network request capture.
 struct NetworkCaptureConfiguration {
+    /// Maximum number of times to send batched requests for a given `Page`.
     public var spanCount: Int
+    /// Duration of time to wait before sending the first batch of captured requests for the current
+    /// `Page`.
     public var initialSpanDuration: TimeInterval
+    /// Duration of time to wait before sending the second and any subsequent batches of captured
+    /// requests for the current `Page`.
     public var subsequentSpanDuration: TimeInterval
 }
 

--- a/Sources/BlueTriangle/NetworkCapture/NetworkCaptureConfiguration.swift
+++ b/Sources/BlueTriangle/NetworkCapture/NetworkCaptureConfiguration.swift
@@ -1,0 +1,18 @@
+//
+//  NetworkCaptureConfiguration.swift
+//
+//  Created by Mathew Gacy on 3/3/22.
+//  Copyright © 2022 Blue Triangle. All rights reserved.
+//
+
+import Foundation
+
+struct NetworkCaptureConfiguration {
+    public var spanCount: Int
+    public var initialSpanDuration: TimeInterval
+    public var subsequentSpanDuration: TimeInterval
+}
+
+extension NetworkCaptureConfiguration {
+    static let standard: Self = .init(spanCount: 2, initialSpanDuration: 20, subsequentSpanDuration: 10)
+}

--- a/Sources/BlueTriangle/NetworkCapture/RequestSpan.swift
+++ b/Sources/BlueTriangle/NetworkCapture/RequestSpan.swift
@@ -1,0 +1,34 @@
+//
+//  RequestSpan.swift
+//
+//  Created by Mathew Gacy on 3/3/22.
+//  Copyright © 2022 Blue Triangle. All rights reserved.
+//
+
+import Foundation
+
+struct RequestSpan: Equatable {
+    let page: Page
+    var requests: [CapturedRequest]
+
+    var isNotEmpty: Bool {
+        !requests.isEmpty
+    }
+
+    init(_ page: Page, requests: [CapturedRequest] = []) {
+        self.page = page
+        self.requests = requests
+    }
+
+    mutating func insert(_ request: CapturedRequest) {
+        requests.append(request)
+    }
+
+    mutating func batchRequests() -> [CapturedRequest]? {
+        guard isNotEmpty else {
+            return nil
+        }
+        defer { requests = [] }
+        return requests
+    }
+}

--- a/Sources/BlueTriangle/NetworkCapture/Timeline.swift
+++ b/Sources/BlueTriangle/NetworkCapture/Timeline.swift
@@ -1,0 +1,91 @@
+//
+//  Timeline.swift
+//
+//  Created by Mathew Gacy on 3/3/22.
+//  Copyright © 2022 Blue Triangle. All rights reserved.
+//
+
+import Foundation
+import DequeModule
+
+struct Timeline<T: Equatable> {
+    final class Span {
+        let startTime: Millisecond
+        var value: T
+
+        init(startTime: Millisecond, value: T) {
+            self.startTime = startTime
+            self.value = value
+        }
+    }
+
+    let capacity: Int
+    private let intervalProvider: () -> TimeInterval
+    private var storage = Deque<Span>()
+
+    var count: Int {
+        storage.count
+    }
+
+    var current: T? {
+        storage.last?.value
+    }
+
+    init(capacity: Int = 5, intervalProvider: @escaping () -> TimeInterval = { Date().timeIntervalSince1970 }) {
+        assert(capacity > 0)
+        self.capacity = capacity
+        self.intervalProvider = intervalProvider
+    }
+
+    @discardableResult
+    mutating func insert(_ value: T) -> T? {
+        storage.append(Span(startTime: intervalProvider().milliseconds, value: value))
+        if storage.count > capacity {
+            return storage.popFirst()?.value
+        }
+        return nil
+    }
+
+    mutating func updateValue(for startTime: Millisecond, transform: (inout T) -> Void) {
+        guard !storage.isEmpty else {
+            return
+        }
+        var currentIndex = storage.count - 1
+        repeat {
+            if storage[currentIndex].startTime <= startTime {
+                transform(&storage[currentIndex].value)
+                return
+            }
+            currentIndex -= 1
+        } while currentIndex >= 0
+    }
+
+    mutating func updateCurrent(transform: (inout T) -> Void) {
+        guard !storage.isEmpty else {
+            return
+        }
+        transform(&storage.last!.value)
+    }
+
+    @discardableResult
+    mutating func pop() -> T? {
+        storage.popFirst()?.value
+    }
+}
+
+// MARK: - Test Support
+extension Timeline {
+    func value(for startTime: Millisecond) -> T? {
+        guard !storage.isEmpty else {
+            return nil
+        }
+        var currentIndex = storage.count - 1
+        repeat {
+            if storage[currentIndex].startTime <= startTime {
+                return storage[currentIndex].value
+            }
+            currentIndex -= 1
+        } while currentIndex >= 0
+        return nil
+    }
+}

--- a/Sources/BlueTriangle/Protocols/CaptureTimerManaging.swift
+++ b/Sources/BlueTriangle/Protocols/CaptureTimerManaging.swift
@@ -1,0 +1,15 @@
+//
+//  CaptureTimerManaging.swift
+//
+//  Created by Mathew Gacy on 3/3/22.
+//  Copyright © 2022 Blue Triangle. All rights reserved.
+//
+
+import Foundation
+
+protocol CaptureTimerManaging {
+    var handler: () -> Void { get set }
+
+    func start()
+    func cancel()
+}

--- a/Tests/BlueTriangleTests/CaptureTimerManagerTests.swift
+++ b/Tests/BlueTriangleTests/CaptureTimerManagerTests.swift
@@ -1,0 +1,111 @@
+//
+//  CaptureTimerManagerTests.swift
+//
+//  Created by Mathew Gacy on 3/3/22.
+//  Copyright © 2022 Blue Triangle. All rights reserved.
+//
+
+import XCTest
+@testable import BlueTriangle
+
+class CaptureTimerManagerTests: XCTestCase {
+    static let timerLeeway = DispatchTimeInterval.nanoseconds(1)
+    static let configuration = NetworkCaptureConfiguration(
+        spanCount: 2,
+        initialSpanDuration: 0.1,
+        subsequentSpanDuration: 0.1)
+
+    func testStartFromInactive() throws {
+        let manager = CaptureTimerManager(
+            queue: Mock.uploaderQueue,
+            configuration: Self.configuration,
+            timerLeeway: Self.timerLeeway)
+
+        let expectedFireCount = Self.configuration.spanCount
+        let fireExpectation = expectation(description: "Timer fired twice.")
+
+        let additionalFireExpectation = expectation(description: "Fire count exceeded spanCount.")
+        additionalFireExpectation.isInverted = true
+
+        var fireCount: Int = 0
+        manager.handler = {
+            fireCount += 1
+            if fireCount == expectedFireCount {
+                fireExpectation.fulfill()
+            } else if fireCount > expectedFireCount {
+                additionalFireExpectation.fulfill()
+            }
+        }
+        manager.start()
+
+        waitForExpectations(timeout: 1)
+        XCTAssertEqual(manager.state, .inactive)
+    }
+
+    func testStartFromActive() throws {
+        let queue = DispatchQueue.main
+        let configuration = NetworkCaptureConfiguration(
+            spanCount: 2,
+            initialSpanDuration: 0.3,
+            subsequentSpanDuration: 0.1)
+
+        let manager = CaptureTimerManager(
+            queue: queue,
+            configuration: configuration,
+            timerLeeway: Self.timerLeeway)
+
+
+        let excessiveFireExpectation = expectation(description: "Fire count exceeded spanCount.")
+        excessiveFireExpectation.isInverted = true
+
+        var fireCount: Int = 0
+        manager.handler = {
+            fireCount += 1
+            if fireCount > 3 {
+                excessiveFireExpectation.fulfill()
+            }
+        }
+
+        manager.start()
+
+        queue.asyncAfter(deadline: .now() + 0.1) {
+            XCTAssertEqual(manager.state, .active(span: 1))
+            XCTAssertEqual(fireCount, 0)
+            manager.start()
+        }
+
+        waitForExpectations(timeout: 1.0)
+        XCTAssertEqual(fireCount, 2)
+    }
+
+    func testCancelFromActive() throws {
+        let queue = DispatchQueue.main
+        let configuration = NetworkCaptureConfiguration(
+            spanCount: 10,
+            initialSpanDuration: 0.2,
+            subsequentSpanDuration: 0.1)
+
+        let manager = CaptureTimerManager(
+            queue: queue,
+            configuration: configuration,
+            timerLeeway: Self.timerLeeway)
+
+
+        let fireExpectation = expectation(description: "Timer fired.")
+        fireExpectation.isInverted = true
+        manager.handler = {
+            fireExpectation.fulfill()
+        }
+
+        manager.start()
+
+        queue.asyncAfter(deadline: .now() + 0.1) {
+            XCTAssertEqual(manager.state, .active(span: 1))
+            manager.cancel()
+            XCTAssertEqual(manager.state, .inactive)
+        }
+
+        waitForExpectations(timeout: 1)
+        XCTAssertEqual(manager.state, .inactive)
+    }
+}

--- a/Tests/BlueTriangleTests/Mock.swift
+++ b/Tests/BlueTriangleTests/Mock.swift
@@ -224,6 +224,17 @@ extension Mock {
         minMemory: 0,
         maxMemory: 0,
         avgMemory: 0)
+
+    static var capturedRequest = CapturedRequest(
+        domain: "cloudfront.net",
+        host: "d33wubrfki0l68",
+        url: "https://d33wubrfki0l68.cloudfront.net/f50c058607f066d0231c1fe6753eac79f17ea447/e6748/static/logo-cw.f6eaf6dc.png",
+        file: "logo-cw.f6eaf6dc.png",
+        startTime: 132,
+        duration: 52,
+        initiatorType: .image,
+        decodedBodySize: 0,
+        encodedBodySize: 0)
 }
 
 // MARK: - Request

--- a/Tests/BlueTriangleTests/TimelineTests.swift
+++ b/Tests/BlueTriangleTests/TimelineTests.swift
@@ -1,0 +1,169 @@
+//
+//  TimelineTests.swift
+//
+//  Created by Mathe  on 3/1/22.
+//  Copyright © 2022 Blue Triangle. All rights reserved.
+//
+
+import XCTest
+@testable import BlueTriangle
+
+final class TimelineTests: XCTestCase {
+    static var timeIntervals: [TimeInterval] = []
+    static var timeIntervalProvider: () -> TimeInterval = {
+        timeIntervals.popLast() ?? 0
+    }
+
+    let timeIntervals: [TimeInterval] = [5.0, 4.0, 3.0, 2.0, 1.0]
+    let pageNames: [String] = ["page_1", "page_2", "page_3", "page_4", "page_5"]
+
+    override func setUp() {
+        Self.timeIntervals = timeIntervals
+    }
+
+    func testInsert() throws {
+        var timeline = Timeline<RequestSpan>(capacity: 5, intervalProvider: Self.timeIntervalProvider)
+        let requestSpan = RequestSpan(Mock.page)
+        timeline.insert(requestSpan)
+        XCTAssertEqual(timeline.current, requestSpan)
+    }
+
+    func testCount() throws {
+        var timeline = Timeline<RequestSpan>(capacity: 5, intervalProvider: Self.timeIntervalProvider)
+        let requestSpan = RequestSpan(Mock.page)
+        XCTAssertEqual(timeline.count, 0)
+        timeline.insert(requestSpan)
+        XCTAssertEqual(timeline.count, 1)
+    }
+
+    func testValueForIfEmpty() throws {
+        let timeline = Timeline<RequestSpan>(capacity: 5)
+        let value = timeline.value(for: 1000)
+        XCTAssertNil(value)
+    }
+
+    func testValueForBefore() throws {
+        var timeline = Timeline<RequestSpan>(capacity: 5, intervalProvider: Self.timeIntervalProvider)
+        timeline.insert(RequestSpan(Mock.page))
+        let value = timeline.value(for: 999)
+        XCTAssertNil(value)
+    }
+
+    func testValueFor() throws {
+        var timeline = Timeline<RequestSpan>(capacity: 5, intervalProvider: Self.timeIntervalProvider)
+        timeline.insert(RequestSpan(Mock.page))
+        let value = timeline.value(for: 1000)!
+        XCTAssertEqual(value.page, Mock.page)
+    }
+
+    func testValueForAfter() throws {
+        var timeline = Timeline<RequestSpan>(capacity: 5, intervalProvider: Self.timeIntervalProvider)
+        timeline.insert(RequestSpan(Mock.page))
+        let value = timeline.value(for: 2000)!
+        XCTAssertEqual(value.page, Mock.page)
+    }
+
+    func testCapacity() throws {
+        let capacity = 4
+        var timeline = Timeline<RequestSpan>(capacity: capacity, intervalProvider: Self.timeIntervalProvider)
+        // Insert spans to reach capacity
+        Array(0...3).map { RequestSpan(Page(pageName: pageNames[$0])) }.forEach { timeline.insert($0) }
+
+        // Insert additional span
+        let popped = timeline.insert(RequestSpan(Page(pageName: pageNames.last!)))!
+        XCTAssertEqual(timeline.count, capacity)
+        XCTAssertEqual(popped.page.pageName, pageNames.first!)
+    }
+
+    func testUpdateValue() throws {
+        var timeline = Timeline<RequestSpan>(capacity: 5, intervalProvider: Self.timeIntervalProvider)
+        let page1 = Page(pageName: pageNames[0])
+        timeline.insert(RequestSpan(page1))
+        let page2 = Page(pageName: pageNames[1])
+        timeline.insert(RequestSpan(page2))
+
+        timeline.updateValue(for: 1050) { $0.insert(Mock.capturedRequest) }
+        let updated = timeline.pop()!
+
+        XCTAssertEqual(updated.page, page1)
+        XCTAssertEqual(updated.requests, [Mock.capturedRequest])
+    }
+
+    func testUpdateCurrent() throws {
+        var timeline = Timeline<RequestSpan>(capacity: 5, intervalProvider: Self.timeIntervalProvider)
+        timeline.insert(RequestSpan(Mock.page))
+
+        timeline.updateCurrent { span in
+            span.insert(Mock.capturedRequest)
+        }
+
+        let updated = timeline.current!
+        XCTAssertEqual(updated.page, Mock.page)
+        XCTAssertEqual(updated.requests, [Mock.capturedRequest])
+    }
+
+    func testPop() throws {
+        var timeline = Timeline<RequestSpan>(capacity: 5, intervalProvider: Self.timeIntervalProvider)
+        pageNames.map { RequestSpan(Page(pageName: $0)) }.forEach { timeline.insert($0) }
+
+        let firstPopped = timeline.pop()
+        XCTAssertEqual(firstPopped?.page.pageName, "page_1")
+        XCTAssertEqual(timeline.count, 4)
+
+        for _ in 0..<4 { timeline.pop() }
+
+        XCTAssertEqual(timeline.count, 0)
+        XCTAssertNil(timeline.current)
+    }
+}
+
+// MARK: - Performance
+extension TimelineTests {
+    /// MacBook Pro (13-inch, M1, 2020) - macOS 11.6.4 - 0.866 sec for 100_000 pages
+    /// average: 0.866
+    /// relative standard deviation: 1.088%
+    /// values: [0.893464, 0.861452, 0.859019, 0.865981, 0.863099, 0.864539, 0.861907, 0.864205, 0.861393, 0.862474]
+    func testPerformance() throws {
+        let totalPageCount: Int = 100_000
+        let currentTimeOffsets: [Millisecond] = [-6543, 100, 200, 300, 400, -1234, -2345, -3456, 500, -4567]
+
+        var currentTime: TimeInterval = 0.0
+        var pageCount: Int = 0
+
+        func makePage() -> Page {
+            pageCount += 1
+            return Page(pageName: "Page \(pageCount)")
+        }
+
+        func makeCapturedRequest(offset: Millisecond) -> CapturedRequest {
+            var request = Mock.capturedRequest
+            request.startTime = currentTime.milliseconds + offset
+            return request
+        }
+
+        var timeline = Timeline<RequestSpan>(capacity: 5, intervalProvider: {
+            currentTime += 1
+            return currentTime
+        })
+
+        self.measure {
+            for _ in 0..<totalPageCount {
+                let _ = timeline.insert(.init(makePage()))
+
+                for offset in currentTimeOffsets {
+                    let startTime = currentTime.milliseconds + offset
+                    timeline.updateValue(for: startTime) { span in
+                        let request = makeCapturedRequest(offset: offset)
+                        span.insert(request)
+                    }
+                }
+
+                var batched: [CapturedRequest]?
+                timeline.updateCurrent { span in
+                    batched = span.batchRequests()
+                }
+                let _ = batched
+            }
+        }
+    }
+}


### PR DESCRIPTION
Protocol, implementation, and tests for an object responsible for managing the timer for `CapturedRequestCollector`. The primary motivation for this design is to avoid the ugliness of real timers while testing the request collector.