### PR TITLE
Fix Hard-Coded Returning VIsitor

### DIFF
--- a/Sources/BlueTriangle/BlueTriangle.swift
+++ b/Sources/BlueTriangle/BlueTriangle.swift
@@ -177,6 +177,16 @@ final public class BlueTriangle: NSObject {
         }
     }
 
+    /// Boolean value indicating whether user is a returning visitor.
+    @objc public static var isReturningVisitor: Bool {
+        get {
+            lock.sync { session.isReturningVisitor }
+        }
+        set {
+            lock.sync { session.isReturningVisitor = newValue }
+        }
+    }
+
     /// A/B testing identifier.
     @objc public static var abTestID: String  {
         get {
@@ -194,7 +204,7 @@ final public class BlueTriangle: NSObject {
             lock.sync { session.campaign }
         }
         set {
-            lock.sync { session.campaign = newValue}
+            lock.sync { session.campaign = newValue }
         }
     }
 

--- a/Sources/BlueTriangle/BlueTriangle.swift
+++ b/Sources/BlueTriangle/BlueTriangle.swift
@@ -40,6 +40,9 @@ final public class BlueTriangleConfiguration: NSObject {
         }
     }
 
+    /// Boolean value indicating whether user is a returning visitor.
+    @objc var isReturningVisitor: Bool = false
+
     /// A/B testing identifier.
     @objc public var abTestID: String = "Default"
 
@@ -104,6 +107,7 @@ extension BlueTriangleConfiguration {
         Session(siteID: siteID,
                 globalUserID: customGlobalUserID ?? globalUserID,
                 sessionID: customSessionID ?? sessionID,
+                isReturningVisitor: isReturningVisitor,
                 abTestID: abTestID,
                 campaign: customCampaign,
                 campaignMedium: campaignMedium,

--- a/Sources/BlueTriangle/Extensions/Bool+Utils.swift
+++ b/Sources/BlueTriangle/Extensions/Bool+Utils.swift
@@ -1,0 +1,14 @@
+//
+//  Bool+Utils.swift
+//
+//  Created by Mathew Gacy on 2/17/22.
+//  Copyright © 2022 Blue Triangle. All rights reserved.
+//
+
+import Foundation
+
+extension Bool {
+    var smallInt: Int {
+        self ? 1 : 0
+    }
+}

--- a/Sources/BlueTriangle/Extensions/Bool+Utils.swift
+++ b/Sources/BlueTriangle/Extensions/Bool+Utils.swift
@@ -9,6 +9,6 @@ import Foundation
 
 extension Bool {
     var smallInt: Int {
-        self ? 1 : 0
+        Int(truncating: self)
     }
 }

--- a/Sources/BlueTriangle/Models/Session.swift
+++ b/Sources/BlueTriangle/Models/Session.swift
@@ -8,7 +8,6 @@
 import Foundation
 
 struct Session: Equatable {
-    let rv = 0
     let wcd = 0
     let eventType = 9
     let navigationType = 9
@@ -23,6 +22,9 @@ struct Session: Equatable {
 
     /// Session ID.
     var sessionID: Identifier
+
+    /// Boolean value indicating whether user is a returning visitor.
+    var isReturningVisitor: Bool
 
     /// A/B testing identifier.
     var abTestID: String

--- a/Sources/BlueTriangle/Models/TimerRequest.swift
+++ b/Sources/BlueTriangle/Models/TimerRequest.swift
@@ -18,7 +18,7 @@ struct TimerRequest: Encodable {
         var con = enc.container(keyedBy: CodingKeys.self)
 
         // Session
-        try con.encode(session.rv, forKey: .rv)
+        try con.encode(session.isReturningVisitor.smallInt, forKey: .rv)
         try con.encode(session.wcd, forKey: .wcd)
         try con.encode(session.eventType, forKey: .eventType)
         try con.encode(session.navigationType, forKey: .navigationType)

--- a/Tests/BlueTriangleTests/Mock.swift
+++ b/Tests/BlueTriangleTests/Mock.swift
@@ -197,6 +197,7 @@ extension Mock {
         siteID: "MY_SITE_ID",
         globalUserID: Mock.globalUserID,
         sessionID: Mock.sessionID,
+        isReturningVisitor: true,
         abTestID: "MY_AB_TEST_ID",
         campaign: "MY_CAMPAIGN",
         campaignMedium: "MY_CAMPAIGN_MEDIUM",

--- a/Tests/ObjcCompatibilityTests/ObjcCompatibilityTests.m
+++ b/Tests/ObjcCompatibilityTests/ObjcCompatibilityTests.m
@@ -62,6 +62,10 @@
     [timer end];
 
     [BlueTriangle endTimer:timer purchaseConfirmation:purchaseConfirmation];
+
+    BTTimer *timer2 = [BlueTriangle makeTimerWithPage:page];
+
+    [BlueTriangle endTimer:timer2 purchaseConfirmation:nil];
 }
 
 @end


### PR DESCRIPTION
The returning visitor (`RV`)  field was hard-coded; this adds an `isReturningVisitor` to `BlueTriangleConfiguration` to allow user specification of value.