### PR TITLE
Fix Missing err.rcv URL Parameter

### DIFF
--- a/Sources/BlueTriangle/CrashReportManager.swift
+++ b/Sources/BlueTriangle/CrashReportManager.swift
@@ -101,6 +101,7 @@ class CrashReportManager: CrashReportManaging {
             "CmpS": session.campaignSource,
             "os": Constants.os,
             "browser": Constants.browser,
+            "browserVersion": Device.bvzn,
             "device": Constants.device
         ]
 


### PR DESCRIPTION
Add missing `browserVersion` URL parameter to `err.rcv` request