### PR TITLE
Fix Build Documentation Workflow

### DIFF
--- a/.github/workflows/generate-docc.yml
+++ b/.github/workflows/generate-docc.yml
@@ -1,5 +1,6 @@
 name: Generate DocC
 on:
+  workflow_dispatch:
   push:
     branches: [ master ]
 

--- a/.github/workflows/generate-docc.yml
+++ b/.github/workflows/generate-docc.yml
@@ -1,7 +1,7 @@
 name: Generate DocC
 on:
   push:
-    branches: [ main ]
+    branches: [ master ]
 
 env:
   GH-PAGES-BRANCH: 'gh-pages'


### PR DESCRIPTION
The documentation generation workflow was configured to build on pushes to a nonexistent `main` branch; this changes it to use `master` and also adds a manual trigger.