### PR TITLE
Specify Separate doccarchive Name in Workflow

### DIFF
--- a/.github/workflows/generate-docc.yml
+++ b/.github/workflows/generate-docc.yml
@@ -8,6 +8,7 @@ env:
   GH-PAGES-BRANCH: 'gh-pages'
   GH-PAGES-PATH: 'gh-pages'
   BUILD-SCHEME: 'blue-triangle'
+  DOCC-NAME: 'BlueTriangle'
   DERIVED-DATA-PATH: '/Users/runner/docbuild'
   HOSTING-BASE-PATH: 'btt-swift-sdk'
 
@@ -32,7 +33,7 @@ jobs:
           # cat build_output.txt
 
           # Find documentation inside docbuild
-          DOCC_DIR=`find ${{ env.DERIVED-DATA-PATH }} -type d -iname "${{ env.BUILD-SCHEME }}.doccarchive"`
+          DOCC_DIR=`find ${{ env.DERIVED-DATA-PATH }} -type d -iname "${{ env.DOCC-NAME }}.doccarchive"`
 
           # Pretty print DocC JSON output so that it can be consistently diffed between commits
           export DOCC_JSON_PRETTYPRINT=YES


### PR DESCRIPTION
Fixes build error on DocC workflow by specifying a separate name for the generated `.doccarchive`. Afterwards, the documentation will be available at: https://blue-triangle-tech.github.io/btt-swift-sdk/documentation/bluetriangle/