### PR TITLE
Request Persistence

### DIFF
--- a/Sources/BlueTriangle/RequestPersistence.swift
+++ b/Sources/BlueTriangle/RequestPersistence.swift
@@ -1,0 +1,79 @@
+//
+//  RequestPersistence.swift
+//
+//  Created by Mathew Gacy on 6/26/22.
+//  Copyright © 2022 Blue Triangle. All rights reserved.
+//
+
+import Foundation
+
+struct RequestPersistence {
+    enum Constants {
+        static let lineBreak = Data([10])
+    }
+
+    private let persistence: Persistence
+    private let logger: Logging
+    private let maxSize: Int
+    private var buffer: Data = .init()
+
+    init(persistence: Persistence, logger: Logging, maxSize: Int = 1024 * 1024) {
+        self.persistence = persistence
+        self.logger = logger
+        self.maxSize = maxSize
+    }
+
+    mutating func save(_ request: Request) {
+        do {
+            let data = try JSONEncoder().encode(request) + Constants.lineBreak
+            buffer.append(data)
+        } catch {
+            let path = persistence.file.path
+            logger.error("Error saving \(request) to \(path): \(error.localizedDescription)")
+        }
+
+        if buffer.count > maxSize {
+            saveBuffer()
+        }
+    }
+    
+    mutating func saveBuffer() {
+        defer {
+            clearBuffer()
+        }
+        do {
+            try persistence.append(buffer)
+        } catch {
+            let path = persistence.file.path
+            logger.error("Error appending buffer to \(path): \(error.localizedDescription)")
+        }
+    }
+
+    func read() throws -> [Request]? {
+        let data: Data
+        if let disk = try persistence.readData() {
+            data = disk + Constants.lineBreak + buffer
+        } else {
+            data = buffer
+        }
+
+        let decoder = JSONDecoder()
+        return try data
+            .split(separator: Constants.lineBreak[0])
+            .map { try decoder.decode(Request.self, from: $0) }
+    }
+
+    mutating func clear() throws {
+        clearBuffer()
+        do {
+        try persistence.clear()
+        } catch {
+            let path = persistence.file.path
+            logger.error("Error removing file at \(path): \(error.localizedDescription)")
+        }
+    }
+
+    private mutating func clearBuffer() {
+        buffer = Data()
+    }
+}

--- a/Tests/BlueTriangleTests/RequestPersistenceTests.swift
+++ b/Tests/BlueTriangleTests/RequestPersistenceTests.swift
@@ -63,6 +63,8 @@ final class RequestPersistenceTests: XCTestCase {
         let request2 = try Request(url: Constants.timerEndpoint, model: Model(id: 2), encode: { try JSONEncoder().encode($0) })
         sut.save(request2)
 
+        XCTAssert(FileManager.default.fileExists(atPath: Self.file.path))
+
         let requests = try sut.read()
         XCTAssertEqual(requests, [request1, request2])
     }

--- a/Tests/BlueTriangleTests/RequestPersistenceTests.swift
+++ b/Tests/BlueTriangleTests/RequestPersistenceTests.swift
@@ -1,0 +1,69 @@
+//
+//  RequestPersistenceTests.swift
+//
+//  Created by Mathew Gacy on 7/7/22.
+//  Copyright © 2022 Blue Triangle. All rights reserved.
+//
+
+import Foundation
+import XCTest
+@testable import BlueTriangle
+
+final class RequestPersistenceTests: XCTestCase {
+    struct Model: Codable {
+        var id: Int
+    }
+
+    static var file: File {
+        let fileLocation = UserLocation.document(Constants.persistenceDirectory)
+        let file = File(fileLocation: fileLocation, name: "test")!
+        return file
+    }
+
+    static var persistence: Persistence {
+        Persistence(file: Self.file)
+    }
+
+    override func tearDownWithError() throws {
+        super.tearDown()
+        do {
+            try FileManager.default.removeItem(at: Self.file.url)
+        } catch CocoaError.Code.fileNoSuchFile {
+            return
+        } catch {
+            throw error
+        }
+    }
+
+    func testRequestPersistenceBuffer() throws {
+        let maxSize: Int = 1024 * 1024
+        let logger = LoggerMock(onError: { XCTFail("Unexpected error: \($0)") })
+
+        var sut = RequestPersistence(persistence: Self.persistence, logger: logger, maxSize: maxSize)
+
+        let request1 = try Request(url: Constants.timerEndpoint, model: Model(id: 1), encode: { try JSONEncoder().encode($0) })
+        sut.save(request1)
+
+        let request2 = try Request(url: Constants.timerEndpoint, model: Model(id: 2), encode: { try JSONEncoder().encode($0) })
+        sut.save(request2)
+
+        let requests = try sut.read()
+        XCTAssertEqual(requests, [request1, request2])
+    }
+
+    func testRequestPersistenceFile() throws {
+        let maxSize: Int = 100
+        let logger = LoggerMock(onError: { XCTFail("Unexpected error: \($0)") })
+
+        var sut = RequestPersistence(persistence: Self.persistence, logger: logger, maxSize: maxSize)
+
+        let request1 = try Request(url: Constants.timerEndpoint, model: Model(id: 1), encode: { try JSONEncoder().encode($0) })
+        sut.save(request1)
+
+        let request2 = try Request(url: Constants.timerEndpoint, model: Model(id: 2), encode: { try JSONEncoder().encode($0) })
+        sut.save(request2)
+
+        let requests = try sut.read()
+        XCTAssertEqual(requests, [request1, request2])
+    }
+}


### PR DESCRIPTION
Adds `RequestPersistence` to store failed requests. It only writes to the file system when its buffer exceeds its `maxSize`