### PR TITLE
Request Failure Handler

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@
 xcuserdata/
 DerivedData/
 .swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+.vscode/
+default.profraw

--- a/Sources/BlueTriangle/AppEventObserver.swift
+++ b/Sources/BlueTriangle/AppEventObserver.swift
@@ -6,30 +6,6 @@
 //
 
 import Foundation
-#if os(iOS) || os(tvOS)
-import UIKit.UIApplication
-
-let launchNotification = UIApplication.didFinishLaunchingNotification
-let activeNotification = UIApplication.didBecomeActiveNotification
-let backgroundNotification = UIApplication.didEnterBackgroundNotification
-let terminateNotification = UIApplication.willTerminateNotification
-#elseif os(watchOS)
-import WatchKit.WKExtension
-
-@available(watchOS 7.0, *)
-let launchNotification = WKExtension.applicationDidFinishLaunchingNotification
-@available(watchOS 7.0, *)
-let activeNotification = WKExtension.applicationDidBecomeActiveNotification
-@available(watchOS 7.0, *)
-let backgroundNotification = WKExtension.applicationDidEnterBackgroundNotification
-#elseif os(macOS)
-import AppKit.NSApplication
-
-let launchNotification = NSApplication.didFinishLaunchingNotification
-let activeNotification = NSApplication.didBecomeActiveNotification
-let backgroundNotification = NSApplication.willResignActiveNotification
-let terminateNotification = NSApplication.willTerminateNotification
-#endif
 
 class AppEventObserver {
     typealias EventHandler = () -> Void
@@ -59,12 +35,12 @@ class AppEventObserver {
             return
         }
         #endif
-        center.addObserver(self, selector: #selector(onDidFinishLaunching(_:)), name: launchNotification, object: nil)
-        center.addObserver(self, selector: #selector(onDidBecomeActive(_:)), name: activeNotification, object: nil)
-        center.addObserver(self, selector: #selector(onDidEnterBackground), name: backgroundNotification, object: nil)
+        center.addObserver(self, selector: #selector(onDidFinishLaunching(_:)), name: .finishedLaunching, object: nil)
+        center.addObserver(self, selector: #selector(onDidBecomeActive(_:)), name: .becameActive, object: nil)
+        center.addObserver(self, selector: #selector(onDidEnterBackground), name: .enteredBackground, object: nil)
 
         #if !os(watchOS)
-        center.addObserver(self, selector: #selector(onWillTerminate(_:)), name: terminateNotification, object: nil)
+        center.addObserver(self, selector: #selector(onWillTerminate(_:)), name: .willTerminate, object: nil)
         #endif
     }
 

--- a/Sources/BlueTriangle/BlueTriangle.swift
+++ b/Sources/BlueTriangle/BlueTriangle.swift
@@ -150,7 +150,11 @@ final public class BlueTriangle: NSObject {
     }()
 
     private static var uploader: Uploading = {
-        configuration.uploaderConfiguration.makeUploader(logger: logger)
+        configuration.uploaderConfiguration.makeUploader(
+            logger: logger,
+            failureHandler: RequestFailureHandler(
+                file: .requests,
+                logger: logger))
     }()
 
     private static var timerFactory: (Page, BTTimer.TimerType) -> BTTimer = {

--- a/Sources/BlueTriangle/Extensions/NWPathMonitor+Combine.swift
+++ b/Sources/BlueTriangle/Extensions/NWPathMonitor+Combine.swift
@@ -1,0 +1,67 @@
+//
+//  NWPathMonitor+Combine.swift
+//
+//  Created by Mathew Gacy on 6/12/22.
+//  Copyright © 2022 Blue Triangle. All rights reserved.
+//
+
+import Combine
+import Network
+
+extension NWPathMonitor {
+    class NetworkStatusSubscription<Target: Subscriber>: Subscription where Target.Input == NWPath {
+        private let monitor: NWPathMonitor
+        private let queue: DispatchQueue
+        private var target: Target?
+
+        init(monitor: NWPathMonitor, queue: DispatchQueue, target: Target) {
+            self.monitor = monitor
+            self.queue = queue
+            self.target = target
+        }
+
+        func request(_ demand: Subscribers.Demand) {
+            monitor.pathUpdateHandler = { [weak self] path in
+                guard let self = self else {
+                    return
+                }
+
+                _ = self.target?.receive(path)
+            }
+
+            monitor.start(queue: queue)
+        }
+
+        func cancel() {
+            monitor.pathUpdateHandler = nil
+            monitor.cancel()
+            target = nil
+        }
+    }
+
+    struct NetworkStatusPublisher: Publisher {
+        typealias Output = NWPath
+        typealias Failure = Never
+
+        private let monitor: NWPathMonitor
+        private let queue: DispatchQueue
+
+        init(monitor: NWPathMonitor, queue: DispatchQueue) {
+            self.monitor = monitor
+            self.queue = queue
+        }
+
+        func receive<S: Subscriber>(subscriber: S) where S.Input == Output, S.Failure == Failure {
+            let subscription = NetworkStatusSubscription(
+                monitor: monitor,
+                queue: queue,
+                target: subscriber)
+
+            subscriber.receive(subscription: subscription)
+        }
+    }
+
+    func publisher(queue: DispatchQueue) -> NWPathMonitor.NetworkStatusPublisher {
+        NetworkStatusPublisher(monitor: self, queue: queue)
+    }
+}

--- a/Sources/BlueTriangle/Extensions/NotificationName+Platform.swift
+++ b/Sources/BlueTriangle/Extensions/NotificationName+Platform.swift
@@ -1,0 +1,57 @@
+//
+//  NotificationName+Platform.swift
+//
+//  Created by Mathew Gacy on 7/2/22.
+//  Copyright © 2022 Blue Triangle. All rights reserved.
+//
+
+#if os(iOS) || os(tvOS)
+import UIKit.UIApplication
+#elseif os(watchOS)
+import WatchKit.WKExtension
+#elseif os(macOS)
+import AppKit.NSApplication
+#endif
+
+extension Notification.Name {
+    @available(watchOS 7.0, *)
+    static var finishedLaunching: Self {
+        #if os(iOS) || os(tvOS)
+        return UIApplication.didFinishLaunchingNotification
+        #elseif os(watchOS)
+        return WKExtension.applicationDidFinishLaunchingNotification
+        #elseif os(macOS)
+        return NSApplication.didFinishLaunchingNotification
+        #endif
+    }
+
+    @available(watchOS 7.0, *)
+    static var becameActive: Self {
+        #if os(iOS) || os(tvOS)
+        return UIApplication.didBecomeActiveNotification
+        #elseif os(watchOS)
+        return WKExtension.applicationDidBecomeActiveNotification
+        #elseif os(macOS)
+        return NSApplication.didBecomeActiveNotification
+        #endif
+    }
+
+    @available(watchOS 7.0, *)
+    static var enteredBackground: Self {
+        #if os(iOS) || os(tvOS)
+        return UIApplication.didEnterBackgroundNotification
+        #elseif os(watchOS)
+        return WKExtension.applicationDidEnterBackgroundNotification
+        #elseif os(macOS)
+        return NSApplication.willResignActiveNotification
+        #endif
+    }
+
+    static var willTerminate: Self {
+        #if os(iOS) || os(tvOS)
+        return UIApplication.willTerminateNotification
+        #elseif os(macOS)
+        return NSApplication.willTerminateNotification
+        #endif
+    }
+}

--- a/Sources/BlueTriangle/InternalTimer.swift
+++ b/Sources/BlueTriangle/InternalTimer.swift
@@ -74,8 +74,7 @@ extension InternalTimer.State: CustomStringConvertible {
 }
 
 extension InternalTimer: CustomStringConvertible {
-    @usableFromInline
-    var description: String {
+    @usableFromInline var description: String {
         "InternalTimer(state: \(state), startTime: \(startTime), endTime: \(endTime))"
     }
 }

--- a/Sources/BlueTriangle/Persistence/Persistence.swift
+++ b/Sources/BlueTriangle/Persistence/Persistence.swift
@@ -17,22 +17,30 @@ struct Persistence {
     }
 
     func write(_ data: Data) throws {
-        try fileManager.createDirectory(at: file.directory, withIntermediateDirectories: true)
-        try data.write(to: file.url, options: .atomic)
+        do {
+            try fileManager.createDirectory(at: file.directory, withIntermediateDirectories: true)
+            try data.write(to: file.url, options: .atomic)
+        } catch {
+            throw PersistenceError.file(path: file.path, error: error)
+        }
     }
 
     func append(_ data: Data) throws {
         if fileManager.fileExists(atPath: file.path) {
-            let fileHandle = try FileHandle(forUpdating: file.url)
+            do {
+                let fileHandle = try FileHandle(forUpdating: file.url)
 
-            if #available(iOS 13.4, macOS 10.15.4, tvOS 13.4, watchOS 6.2, *) {
-                try fileHandle.seekToEnd()
-                try fileHandle.write(contentsOf: data)
-                try fileHandle.close()
-            } else {
-                fileHandle.seekToEndOfFile()
-                fileHandle.write(data)
-                fileHandle.closeFile()
+                if #available(iOS 13.4, macOS 10.15.4, tvOS 13.4, watchOS 6.2, *) {
+                    try fileHandle.seekToEnd()
+                    try fileHandle.write(contentsOf: data)
+                    try fileHandle.close()
+                } else {
+                    fileHandle.seekToEndOfFile()
+                    fileHandle.write(data)
+                    fileHandle.closeFile()
+                }
+            } catch {
+                throw PersistenceError.file(path: file.path, error: error)
             }
         } else {
             try write(data)
@@ -45,7 +53,7 @@ struct Persistence {
         } catch CocoaError.Code.fileReadNoSuchFile {
             return nil
         } catch {
-            throw error
+            throw PersistenceError.file(path: file.path, error: error)
         }
     }
 
@@ -55,22 +63,30 @@ struct Persistence {
         } catch CocoaError.Code.fileNoSuchFile {
             return
         } catch {
-            throw error
+            throw PersistenceError.file(path: file.path, error: error)
         }
     }
 }
 
 extension Persistence {
     func save<T: Encodable>(_ object: T, encodingWith encoder: JSONEncoder = .init()) throws {
-        let data = try encoder.encode(object)
-        try write(data)
+        do {
+            let data = try encoder.encode(object)
+            try write(data)
+        } catch {
+            throw PersistenceError(underlyingError: error)
+        }
     }
 
     func read<T: Decodable>(decodingWith decoder: JSONDecoder = .init()) throws -> T? {
         guard let data = try readData() else {
             return nil
         }
-        let object = try decoder.decode(T.self, from: data)
-        return object
+        do {
+            let object = try decoder.decode(T.self, from: data)
+            return object
+        } catch {
+            throw PersistenceError(underlyingError: error)
+        }
     }
 }

--- a/Sources/BlueTriangle/Persistence/PersistenceError.swift
+++ b/Sources/BlueTriangle/Persistence/PersistenceError.swift
@@ -1,0 +1,38 @@
+//
+//  PersistenceError.swift
+//
+//  Created by Mathew Gacy on 7/18/22.
+//  Copyright © 2022 Blue Triangle. All rights reserved.
+//
+
+import Foundation
+
+enum PersistenceError: Error {
+    case encoding(EncodingError)
+    case decoding(DecodingError)
+    case file(path: String, error: Error)
+
+    init(underlyingError: Error, path: String = "") {
+        switch underlyingError {
+        case let error as EncodingError:
+            self = .encoding(error)
+        case let error as DecodingError:
+            self = .decoding(error)
+        case let error as PersistenceError:
+            self = error
+        default:
+            self = .file(path: path, error: underlyingError)
+        }
+    }
+
+    var localizedDescription: String {
+        switch self {
+        case let .encoding(error):
+            return error.localizedDescription
+        case let .decoding(error):
+            return error.localizedDescription
+        case let .file(path: path, error: error):
+            return "Operation on \(path) failed: \(error.localizedDescription)"
+        }
+    }
+}

--- a/Sources/BlueTriangle/Protocols/RequestFailureHandling.swift
+++ b/Sources/BlueTriangle/Protocols/RequestFailureHandling.swift
@@ -1,0 +1,18 @@
+//
+//  RequestFailureHandling.swift
+//
+//  Created by Mathew Gacy on 7/17/22.
+//  Copyright © 2022 Blue Triangle. All rights reserved.
+//
+
+import Combine
+import Foundation
+import Network
+
+protocol RequestFailureHandling: AnyObject {
+    var send: ((Request) -> Void)? { get set }
+
+    func configureSubscriptions(queue: DispatchQueue)
+    func store(request: Request)
+    func sendSaved()
+}

--- a/Sources/BlueTriangle/RequestCache.swift
+++ b/Sources/BlueTriangle/RequestCache.swift
@@ -1,5 +1,5 @@
 //
-//  RequestPersistence.swift
+//  RequestCache.swift
 //
 //  Created by Mathew Gacy on 6/26/22.
 //  Copyright © 2022 Blue Triangle. All rights reserved.
@@ -7,7 +7,7 @@
 
 import Foundation
 
-struct RequestPersistence {
+struct RequestCache {
     enum Constants {
         static let lineBreak = Data([10])
     }

--- a/Sources/BlueTriangle/RequestFailureHandler.swift
+++ b/Sources/BlueTriangle/RequestFailureHandler.swift
@@ -19,8 +19,7 @@ final class RequestFailureHandler: RequestFailureHandling {
     init(persistence: RequestCache, logger: Logging) {
         self.persistence = persistence
         self.logger = logger
-        let networkMonitor = NWPathMonitor()
-        self.networkMonitor = networkMonitor
+        self.networkMonitor = NWPathMonitor()
     }
 
     convenience init?(file: File?, logger: Logging) {

--- a/Sources/BlueTriangle/RequestFailureHandler.swift
+++ b/Sources/BlueTriangle/RequestFailureHandler.swift
@@ -1,0 +1,55 @@
+//
+//  RequestFailureHandler.swift
+//
+//  Created by Mathew Gacy on 6/12/22.
+//  Copyright © 2022 Blue Triangle. All rights reserved.
+//
+
+import Combine
+import Foundation
+import Network
+
+final class RequestFailureHandler: RequestFailureHandling {
+    private var persistence: RequestCache
+    private let networkMonitor: NWPathMonitor
+    private var cancellables = Set<AnyCancellable>()
+    var send: ((Request) -> Void)?
+
+    init(persistence: RequestCache) {
+        self.persistence = persistence
+        let networkMonitor = NWPathMonitor()
+        self.networkMonitor = networkMonitor
+    }
+
+    convenience init?(file: File?, logger: Logging) {
+        guard let file = file else {
+            return nil
+        }
+        self.init(persistence: RequestCache(persistence: Persistence(file: file), logger: logger))
+    }
+
+    func configureSubscriptions(queue: DispatchQueue) {
+        networkMonitor.publisher(queue: queue)
+            .filter { $0.status == .satisfied }
+            .sink { [weak self] path in
+                self?.sendSaved()
+            }.store(in: &cancellables)
+
+        NotificationCenter.default.publisher(for: .willTerminate)
+            .sink { [weak self] _ in
+                self?.persistence.saveBuffer()
+            }.store(in: &cancellables)
+    }
+
+    func store(request: Request) {
+        persistence.save(request)
+    }
+
+    func sendSaved() {
+        guard let send = send, let requests = persistence.read() else {
+            return
+        }
+
+        requests.forEach { send($0) }
+    }
+}

--- a/Tests/BlueTriangleTests/BlueTriangleTests.swift
+++ b/Tests/BlueTriangleTests/BlueTriangleTests.swift
@@ -51,6 +51,7 @@ final class BlueTriangleTests: XCTestCase {
     override class func tearDown() {
         super.tearDown()
         BlueTriangle.reset()
+        Self.onSendRequest = { _ in }
     }
 
     override func setUp() {

--- a/Tests/BlueTriangleTests/RequestCacheTests.swift
+++ b/Tests/BlueTriangleTests/RequestCacheTests.swift
@@ -37,35 +37,31 @@ final class RequestCacheTests: XCTestCase {
 
     func testRequestPersistenceBuffer() throws {
         let maxSize: Int = 1024 * 1024
-        let logger = LoggerMock(onError: { XCTFail("Unexpected error: \($0)") })
-
-        var sut = RequestCache(persistence: Self.persistence, logger: logger, maxSize: maxSize)
+        var sut = RequestCache(persistence: Self.persistence, maxSize: maxSize)
 
         let request1 = try Request(url: Constants.timerEndpoint, model: Model(id: 1), encode: { try JSONEncoder().encode($0) })
-        sut.save(request1)
+        try sut.save(request1)
 
         let request2 = try Request(url: Constants.timerEndpoint, model: Model(id: 2), encode: { try JSONEncoder().encode($0) })
-        sut.save(request2)
+        try sut.save(request2)
 
-        let requests = sut.read()
+        let requests = try sut.read()
         XCTAssertEqual(requests, [request1, request2])
     }
 
     func testRequestPersistenceFile() throws {
         let maxSize: Int = 100
-        let logger = LoggerMock(onError: { XCTFail("Unexpected error: \($0)") })
-
-        var sut = RequestCache(persistence: Self.persistence, logger: logger, maxSize: maxSize)
+        var sut = RequestCache(persistence: Self.persistence, maxSize: maxSize)
 
         let request1 = try Request(url: Constants.timerEndpoint, model: Model(id: 1), encode: { try JSONEncoder().encode($0) })
-        sut.save(request1)
+        try sut.save(request1)
 
         let request2 = try Request(url: Constants.timerEndpoint, model: Model(id: 2), encode: { try JSONEncoder().encode($0) })
-        sut.save(request2)
+        try sut.save(request2)
 
         XCTAssert(FileManager.default.fileExists(atPath: Self.file.path))
 
-        let requests = sut.read()
+        let requests = try sut.read()
         XCTAssertEqual(requests, [request1, request2])
     }
 }

--- a/Tests/BlueTriangleTests/RequestCacheTests.swift
+++ b/Tests/BlueTriangleTests/RequestCacheTests.swift
@@ -1,5 +1,5 @@
 //
-//  RequestPersistenceTests.swift
+//  RequestCacheTests.swift
 //
 //  Created by Mathew Gacy on 7/7/22.
 //  Copyright © 2022 Blue Triangle. All rights reserved.
@@ -9,7 +9,7 @@ import Foundation
 import XCTest
 @testable import BlueTriangle
 
-final class RequestPersistenceTests: XCTestCase {
+final class RequestCacheTests: XCTestCase {
     struct Model: Codable {
         var id: Int
     }
@@ -39,7 +39,7 @@ final class RequestPersistenceTests: XCTestCase {
         let maxSize: Int = 1024 * 1024
         let logger = LoggerMock(onError: { XCTFail("Unexpected error: \($0)") })
 
-        var sut = RequestPersistence(persistence: Self.persistence, logger: logger, maxSize: maxSize)
+        var sut = RequestCache(persistence: Self.persistence, logger: logger, maxSize: maxSize)
 
         let request1 = try Request(url: Constants.timerEndpoint, model: Model(id: 1), encode: { try JSONEncoder().encode($0) })
         sut.save(request1)
@@ -55,7 +55,7 @@ final class RequestPersistenceTests: XCTestCase {
         let maxSize: Int = 100
         let logger = LoggerMock(onError: { XCTFail("Unexpected error: \($0)") })
 
-        var sut = RequestPersistence(persistence: Self.persistence, logger: logger, maxSize: maxSize)
+        var sut = RequestCache(persistence: Self.persistence, logger: logger, maxSize: maxSize)
 
         let request1 = try Request(url: Constants.timerEndpoint, model: Model(id: 1), encode: { try JSONEncoder().encode($0) })
         sut.save(request1)

--- a/Tests/BlueTriangleTests/RequestPersistenceTests.swift
+++ b/Tests/BlueTriangleTests/RequestPersistenceTests.swift
@@ -47,7 +47,7 @@ final class RequestPersistenceTests: XCTestCase {
         let request2 = try Request(url: Constants.timerEndpoint, model: Model(id: 2), encode: { try JSONEncoder().encode($0) })
         sut.save(request2)
 
-        let requests = try sut.read()
+        let requests = sut.read()
         XCTAssertEqual(requests, [request1, request2])
     }
 
@@ -65,7 +65,7 @@ final class RequestPersistenceTests: XCTestCase {
 
         XCTAssert(FileManager.default.fileExists(atPath: Self.file.path))
 
-        let requests = try sut.read()
+        let requests = sut.read()
         XCTAssertEqual(requests, [request1, request2])
     }
 }

--- a/Tests/BlueTriangleTests/UploaderTests.swift
+++ b/Tests/BlueTriangleTests/UploaderTests.swift
@@ -163,6 +163,7 @@ final class UploaderTests: XCTestCase {
         let uploader = Uploader(queue: uploaderQueue,
                                 logger: logger,
                                 networking: networking,
+                                failureHandler: nil,
                                 retryConfiguration: Mock.retryConfiguration)
 
         let group = DispatchGroup()

--- a/Tests/ObjcCompatibilityTests/ObjcCompatibilityTests.m
+++ b/Tests/ObjcCompatibilityTests/ObjcCompatibilityTests.m
@@ -64,7 +64,7 @@
 
     [BlueTriangle endTimer:timer purchaseConfirmation:purchaseConfirmation];
 
-    BTTimer *timer2 = [BlueTriangle makeTimerWithPage:page timerType:TimerTypeCustom];
+    BTTimer *timer2 = [BlueTriangle startTimerWithPage:page timerType:TimerTypeCustom];
 
     [BlueTriangle endTimer:timer2 purchaseConfirmation:nil];
 


### PR DESCRIPTION
Adds `RequestFailureHandler`, which accepts failed requests and tries to resend them when a network connection is re-established. 

- `Uploader` owns `RequestFailureHandler`, configures it with a `(Request) -> Void` closure to re-send requests, and sends failed requests to it.
- `RequestFailureHandler` owns an instance of `RequestCache` to manage storage of requests and subscribes to a `Publisher` added to `NWPathMonitor` to resend notifications once a connection is re-established.

Additional:

- adds `PersistenceError`, renames `RequestPersistence` as `RequestCache`, and makes its methods throwing .
- moves handling of platform-specific app lifecycle notifications into an extension on `Notification.Name`
- fixes a couple tests