### PR TITLE
Fix Test on CI

### DIFF
--- a/Sources/BlueTriangle/Extensions/Bool+Utils.swift
+++ b/Sources/BlueTriangle/Extensions/Bool+Utils.swift
@@ -22,4 +22,15 @@ extension Bool {
         }
         return Double.random(in: 0...1) <= probability
     }
+
+    init?(_ int: Int) {
+        switch int {
+        case 0:
+            self = false
+        case 1:
+            self = true
+        default:
+            return nil
+        }
+    }
 }

--- a/Sources/BlueTriangle/Models/PerformanceReport.swift
+++ b/Sources/BlueTriangle/Models/PerformanceReport.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-struct PerformanceReport: Codable {
+struct PerformanceReport: Codable, Equatable {
     let minCPU: Float
     let maxCPU: Float
     let avgCPU: Float

--- a/Sources/BlueTriangle/Models/PurchaseConfirmation.swift
+++ b/Sources/BlueTriangle/Models/PurchaseConfirmation.swift
@@ -30,6 +30,13 @@ final public class PurchaseConfirmation: NSObject {
         self.cartValue = cartValue
         self.orderNumber = orderNumber
     }
+
+    init(pageValue: Decimal = 0.0, cartValue: Decimal, orderNumber: String, orderTime: TimeInterval = 0.0) {
+        self.pageValue = pageValue
+        self.cartValue = cartValue
+        self.orderNumber = orderNumber
+        self.orderTime = orderTime
+    }
 }
 
 // MARK: - Equatable

--- a/Sources/BlueTriangle/Models/TimerRequest.swift
+++ b/Sources/BlueTriangle/Models/TimerRequest.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-struct TimerRequest {
+struct TimerRequest: Equatable {
     let session: Session
     let page: Page
     let timer: PageTimeInterval

--- a/Sources/BlueTriangle/Models/TimerRequest.swift
+++ b/Sources/BlueTriangle/Models/TimerRequest.swift
@@ -7,14 +7,15 @@
 
 import Foundation
 
-struct TimerRequest: Encodable {
+struct TimerRequest {
     let session: Session
     let page: Page
     let timer: PageTimeInterval
     let purchaseConfirmation: PurchaseConfirmation?
     let performanceReport: PerformanceReport?
+}
 
-    // swiftlint:disable:next function_body_length
+extension TimerRequest: Codable {
     func encode(to enc: Encoder) throws {
         var con = enc.container(keyedBy: CodingKeys.self)
 
@@ -114,6 +115,120 @@ struct TimerRequest: Encodable {
             try con.encode(performanceReport.minMemory, forKey: .minMemory)
             try con.encode(performanceReport.maxMemory, forKey: .maxMemory)
             try con.encode(performanceReport.avgMemory, forKey: .avgMemory)
+        }
+    }
+
+    init(from decoder: Decoder) throws {
+        let container: KeyedDecodingContainer<CodingKeys> = try decoder.container(keyedBy: CodingKeys.self)
+
+        // Session
+        guard let isReturningVisitor = Bool(try container.decode(Int.self, forKey: CodingKeys.rv)) else {
+            throw DecodingError.keyNotFound(
+                CodingKeys.rv,
+                DecodingError.Context(codingPath: [CodingKeys.rv], debugDescription: ""))
+        }
+
+        self.session = Session(
+            siteID: try container.decode(String.self, forKey: CodingKeys.siteID),
+            globalUserID: try container.decode(Identifier.self, forKey: CodingKeys.globalUserID),
+            sessionID: try container.decode(Identifier.self, forKey: CodingKeys.sessionID),
+            isReturningVisitor: isReturningVisitor,
+            abTestID: try container.decode(String.self, forKey: CodingKeys.abTestID),
+            campaign: try container.decodeIfPresent(String.self, forKey: CodingKeys.campaign),
+            campaignMedium: try container.decode(String.self, forKey: CodingKeys.campaignMedium),
+            campaignName: try container.decode(String.self, forKey: CodingKeys.campaignName),
+            campaignSource: try container.decode(String.self, forKey: CodingKeys.campaignSource),
+            dataCenter: try container.decode(String.self, forKey: CodingKeys.dataCenter),
+            trafficSegmentName: try container.decode(String.self, forKey: CodingKeys.trafficSegmentName))
+
+        // CustomVariables
+        let customVariables = CustomVariables(
+            cv1: try container.decodeIfPresent(String.self, forKey: CodingKeys.cv1),
+            cv2: try container.decodeIfPresent(String.self, forKey: CodingKeys.cv2),
+            cv3: try container.decodeIfPresent(String.self, forKey: CodingKeys.cv3),
+            cv4: try container.decodeIfPresent(String.self, forKey: CodingKeys.cv4),
+            cv5: try container.decodeIfPresent(String.self, forKey: CodingKeys.cv5),
+            cv11: try container.decodeIfPresent(String.self, forKey: CodingKeys.cv11),
+            cv12: try container.decodeIfPresent(String.self, forKey: CodingKeys.cv12),
+            cv13: try container.decodeIfPresent(String.self, forKey: CodingKeys.cv13),
+            cv14: try container.decodeIfPresent(String.self, forKey: CodingKeys.cv14),
+            cv15: try container.decodeIfPresent(String.self, forKey: CodingKeys.cv15))
+
+        // CustomCategories
+        let customCategories = CustomCategories(
+            cv6: try container.decodeIfPresent(String.self, forKey: CodingKeys.cv6),
+            cv7: try container.decodeIfPresent(String.self, forKey: CodingKeys.cv7),
+            cv8: try container.decodeIfPresent(String.self, forKey: CodingKeys.cv8),
+            cv9: try container.decodeIfPresent(String.self, forKey: CodingKeys.cv9),
+            cv10: try container.decodeIfPresent(String.self, forKey: CodingKeys.cv10))
+
+        // CustomNumbers
+        let customNumbers: CustomNumbers?
+        if let cn1 = try container.decodeIfPresent(Double.self, forKey: CodingKeys.cn1) {
+            customNumbers = CustomNumbers(
+                cn1: cn1,
+                cn2: try container.decode(Double.self, forKey: CodingKeys.cn2),
+                cn3: try container.decode(Double.self, forKey: CodingKeys.cn3),
+                cn4: try container.decode(Double.self, forKey: CodingKeys.cn4),
+                cn5: try container.decode(Double.self, forKey: CodingKeys.cn5),
+                cn6: try container.decode(Double.self, forKey: CodingKeys.cn6),
+                cn7: try container.decode(Double.self, forKey: CodingKeys.cn7),
+                cn8: try container.decode(Double.self, forKey: CodingKeys.cn8),
+                cn9: try container.decode(Double.self, forKey: CodingKeys.cn9),
+                cn10: try container.decode(Double.self, forKey: CodingKeys.cn10),
+                cn11: try container.decode(Double.self, forKey: CodingKeys.cn11),
+                cn12: try container.decode(Double.self, forKey: CodingKeys.cn12),
+                cn13: try container.decode(Double.self, forKey: CodingKeys.cn13),
+                cn14: try container.decode(Double.self, forKey: CodingKeys.cn14),
+                cn15: try container.decode(Double.self, forKey: CodingKeys.cn15),
+                cn16: try container.decode(Double.self, forKey: CodingKeys.cn16),
+                cn17: try container.decode(Double.self, forKey: CodingKeys.cn17),
+                cn18: try container.decode(Double.self, forKey: CodingKeys.cn18),
+                cn19: try container.decode(Double.self, forKey: CodingKeys.cn19),
+                cn20: try container.decode(Double.self, forKey: CodingKeys.cn20))
+        } else {
+            customNumbers = nil
+        }
+
+        // Page
+        self.page = Page(
+            pageName: try container.decode(String.self, forKey: CodingKeys.pageName),
+            brandValue: try container.decode(Decimal.self, forKey: CodingKeys.brandValue),
+            pageType: try container.decode(String.self, forKey: CodingKeys.pageType),
+            referringURL: try container.decode(String.self, forKey: CodingKeys.referringURL),
+            url: try container.decode(String.self, forKey: CodingKeys.url),
+            customVariables: customVariables,
+            customCategories: customCategories,
+            customNumbers: customNumbers)
+
+        // Timer
+        self.timer = PageTimeInterval(
+            startTime: try container.decode(Millisecond.self, forKey: CodingKeys.navigationStart),
+            interactiveTime: try container.decode(Millisecond.self, forKey: CodingKeys.domInteractive),
+            pageTime: try container.decode(Millisecond.self, forKey: CodingKeys.pageTime))
+
+        // PurchaseConfirmation
+        if let pageValue = try container.decodeIfPresent(Decimal.self, forKey: CodingKeys.pageValue) {
+            self.purchaseConfirmation = PurchaseConfirmation(
+                pageValue: pageValue,
+                cartValue: try container.decode(Decimal.self, forKey: CodingKeys.cartValue),
+                orderNumber: try container.decode(String.self, forKey: CodingKeys.orderNumber),
+                orderTime: try container.decode(TimeInterval.self, forKey: CodingKeys.orderTime))
+        } else {
+            self.purchaseConfirmation = nil
+        }
+
+        // PerformanceReport
+        if let minCPU = try container.decodeIfPresent(Float.self, forKey: CodingKeys.minCPU) {
+            self.performanceReport = PerformanceReport(
+                minCPU: minCPU,
+                maxCPU: try container.decode(Float.self, forKey: CodingKeys.maxCPU),
+                avgCPU: try container.decode(Float.self, forKey: CodingKeys.avgCPU),
+                minMemory: try container.decode(UInt64.self, forKey: CodingKeys.minMemory),
+                maxMemory: try container.decode(UInt64.self, forKey: CodingKeys.maxMemory),
+                avgMemory: try container.decode(UInt64.self, forKey: CodingKeys.avgMemory))
+        } else {
+            self.performanceReport = nil
         }
     }
 

--- a/Tests/BlueTriangleTests/BlueTriangleTests.swift
+++ b/Tests/BlueTriangleTests/BlueTriangleTests.swift
@@ -363,7 +363,12 @@ extension BlueTriangleTests {
         print(performanceMonitor.measurements)
 
         let base64Decoded = Data(base64Encoded: request.body!)!
-        let requestString = String(data: base64Decoded, encoding: .utf8)
+        let performanceReport = try JSONDecoder().decode(TimerRequest.self, from: base64Decoded).performanceReport!
+        XCTAssertNotEqual(performanceReport.maxCPU, 0.0)
+        XCTAssertNotEqual(performanceReport.avgCPU, 0.0)
+        XCTAssertNotEqual(performanceReport.minMemory, 0)
+        XCTAssertNotEqual(performanceReport.maxMemory, 0)
+        XCTAssertNotEqual(performanceReport.avgMemory, 0)
     }
 
     @available(iOS 14.0, *)
@@ -422,7 +427,12 @@ extension BlueTriangleTests {
         XCTAssertNotNil(finishedTimer)
 
         let base64Decoded = Data(base64Encoded: request.body!)!
-        let requestString = String(data: base64Decoded, encoding: .utf8)
+        let performanceReport = try JSONDecoder().decode(TimerRequest.self, from: base64Decoded).performanceReport!
+        XCTAssertNotEqual(performanceReport.maxCPU, 0.0)
+        XCTAssertNotEqual(performanceReport.avgCPU, 0.0)
+        XCTAssertNotEqual(performanceReport.minMemory, 0)
+        XCTAssertNotEqual(performanceReport.maxMemory, 0)
+        XCTAssertNotEqual(performanceReport.avgMemory, 0)
     }
 
     @available(iOS 14.0, *)

--- a/Tests/BlueTriangleTests/BlueTriangleTests.swift
+++ b/Tests/BlueTriangleTests/BlueTriangleTests.swift
@@ -12,7 +12,7 @@ import Combine
 // swiftlint:disable function_body_length
 final class BlueTriangleTests: XCTestCase {
     static var timeIntervals: [TimeInterval] = []
-    static var timeIntervalProvider: () -> TimeInterval = {
+    static let timeIntervalProvider: () -> TimeInterval = {
         timeIntervals.popLast() ?? 0
     }
 
@@ -53,26 +53,14 @@ final class BlueTriangleTests: XCTestCase {
         BlueTriangle.reset()
     }
 
-    override func setUp() {
-        super.setUp()
-        Self.timeIntervals = []
-        Self.logger.reset()
-        Self.performanceMonitor.reset()
+    override func tearDown() {
+        super.tearDown()
         Self.onMakeTimer = { _, _ in }
         Self.onBuildRequest = { _, _, _ in }
         Self.onSendRequest = { _ in }
-
-        let configuration = BlueTriangleConfiguration()
-        Mock.configureBlueTriangle(configuration: configuration)
-        configuration.requestBuilder = Self.requestBuilder
-
-        BlueTriangle.reconfigure(
-            configuration: configuration,
-            logger: Self.logger,
-            uploader: Self.uploader,
-            timerFactory: Self.timerFactory,
-            requestCollector: nil
-        )
+        Self.logger.reset()
+        Self.performanceMonitor.reset()
+        BlueTriangle.reset()
     }
 }
 
@@ -87,7 +75,7 @@ extension BlueTriangleTests {
         Self.timeIntervals = [
             expectedEndTime,
             expectedInteractiveTime,
-            expectedStartTime,
+            expectedStartTime
         ]
 
         // Performance Monitor
@@ -118,6 +106,22 @@ extension BlueTriangleTests {
             requestExpectation.fulfill()
         }
 
+        // BlueTriangleConfiguration
+        let configuration = BlueTriangleConfiguration()
+        Mock.configureBlueTriangle(configuration: configuration)
+        configuration.requestBuilder = Self.requestBuilder
+
+        // Configure Blue Triangle
+        BlueTriangle.reconfigure(
+            configuration: configuration,
+            logger: Self.logger,
+            uploader: Self.uploader,
+            timerFactory: Self.timerFactory,
+            shouldCaptureRequests: false,
+            requestCollector: nil
+        )
+
+        // Timer
         let timer = BlueTriangle.makeTimer(page: Mock.page)
         XCTAssertEqual(timer.state, expectedInitialState)
 
@@ -182,6 +186,22 @@ extension BlueTriangleTests {
             requestExpectation.fulfill()
         }
 
+        // BlueTriangleConfiguration
+        let configuration = BlueTriangleConfiguration()
+        Mock.configureBlueTriangle(configuration: configuration)
+        configuration.requestBuilder = Self.requestBuilder
+
+        // Configure Blue Triangle
+        BlueTriangle.reconfigure(
+            configuration: configuration,
+            logger: Self.logger,
+            uploader: Self.uploader,
+            timerFactory: Self.timerFactory,
+            shouldCaptureRequests: false,
+            requestCollector: nil
+        )
+
+        // Timer
         let timer = BlueTriangle.startTimer(page: Mock.page)
         XCTAssertEqual(timer.state, expectedInitialState)
 
@@ -241,25 +261,27 @@ extension BlueTriangleTests {
         // Uploader
         var capturedRequest: Request!
         let requestExpectation = self.expectation(description: "Request sent")
-        let uploader = UploaderMock { req in
+        let capturedRequestUploader = UploaderMock { req in
             capturedRequest = req
             requestExpectation.fulfill()
         }
 
-        // Configure
+        // BlueTriangleConfiguration
         let configuration = BlueTriangleConfiguration()
         Mock.configureBlueTriangle(configuration: configuration)
+        configuration.requestBuilder = Self.requestBuilder
 
+        // Configure Blue Triangle
         let requestCollector = Mock.makeRequestCollectorConfiguration()
             .makeRequestCollector(
                 logger: Self.logger,
                 networkCaptureConfiguration: .standard,
                 requestBuilder: .makeBuilder { Mock.session },
-                uploader: uploader)
+                uploader: capturedRequestUploader)
 
         BlueTriangle.reconfigure(
             configuration: configuration,
-            uploader: uploader,
+            uploader: Self.uploader,
             timerFactory: timerFactory,
             shouldCaptureRequests: true,
             internalTimerFactory: { InternalTimer(logger: Self.logger, intervalProvider: requestTimerIntervalProvider) },
@@ -312,12 +334,20 @@ extension BlueTriangleTests {
             requestExpectation.fulfill()
         }
 
-        // Configure
+        // BlueTriangleConfiguration
         let configuration = BlueTriangleConfiguration()
         Mock.configureBlueTriangle(configuration: configuration)
         configuration.requestBuilder = Self.requestBuilder
-        BlueTriangle.reconfigure(configuration: configuration,
-                                 timerFactory: timerFactory)
+
+        // Configure Blue Triangle
+        BlueTriangle.reconfigure(
+            configuration: configuration,
+            logger: Self.logger,
+            uploader: Self.uploader,
+            timerFactory: timerFactory,
+            shouldCaptureRequests: false,
+            requestCollector: nil
+        )
 
         // ViewController
         let imageSize: CGSize = .init(width: 150, height: 150)
@@ -364,12 +394,20 @@ extension BlueTriangleTests {
             requestExpectation.fulfill()
         }
 
-        // Configure
+        // BlueTriangleConfiguration
         let configuration = BlueTriangleConfiguration()
         Mock.configureBlueTriangle(configuration: configuration)
         configuration.requestBuilder = Self.requestBuilder
-        BlueTriangle.reconfigure(configuration: configuration,
-                                 timerFactory: timerFactory)
+
+        // Configure Blue Triangle
+        BlueTriangle.reconfigure(
+            configuration: configuration,
+            logger: Self.logger,
+            uploader: Self.uploader,
+            timerFactory: timerFactory,
+            shouldCaptureRequests: false,
+            requestCollector: nil
+        )
 
         // ViewController
         let imageSize: CGSize = .init(width: 150, height: 150)
@@ -413,12 +451,20 @@ extension BlueTriangleTests {
             requestExpectation.fulfill()
         }
 
-        // Configure
+        // BlueTriangleConfiguration
         let configuration = BlueTriangleConfiguration()
         Mock.configureBlueTriangle(configuration: configuration)
         configuration.requestBuilder = Self.requestBuilder
-        BlueTriangle.reconfigure(configuration: configuration,
-                                 timerFactory: timerFactory)
+
+        // Configure Blue Triangle
+        BlueTriangle.reconfigure(
+            configuration: configuration,
+            logger: Self.logger,
+            uploader: Self.uploader,
+            timerFactory: timerFactory,
+            shouldCaptureRequests: false,
+            requestCollector: nil
+        )
 
         // ViewController
         let imageSize: CGSize = .init(width: 150, height: 150)

--- a/Tests/BlueTriangleTests/BlueTriangleTests.swift
+++ b/Tests/BlueTriangleTests/BlueTriangleTests.swift
@@ -74,25 +74,6 @@ final class BlueTriangleTests: XCTestCase {
             requestCollector: nil
         )
     }
-
-    func testOSInfo() {
-        let os = Device.os
-        let osVersion = Device.osVersion
-        let name = Device.name
-
-        #if os(iOS)
-        XCTAssertEqual(os, "iOS")
-        #elseif os(tvOS)
-        XCTAssertEqual(os, "tvOS")
-        #elseif os(watchOS)
-        XCTAssertEqual(os, "watchOS")
-        #elseif os(macOS)
-        XCTAssertEqual(os, "macOS")
-        #endif
-
-        XCTAssertFalse(osVersion.isEmpty)
-        XCTAssertFalse(name.isEmpty)
-    }
 }
 
 // MARK: - Timer

--- a/Tests/BlueTriangleTests/DeviceTests.swift
+++ b/Tests/BlueTriangleTests/DeviceTests.swift
@@ -1,0 +1,30 @@
+//
+//  DeviceTests.swift
+//
+//  Created by Mathew Gacy on 7/18/22.
+//  Copyright © 2022 Blue Triangle. All rights reserved.
+//
+
+import XCTest
+@testable import BlueTriangle
+
+final class DeviceTests: XCTestCase {
+    func testOSInfo() {
+        let os = Device.os
+        let osVersion = Device.osVersion
+        let name = Device.name
+
+        #if os(iOS)
+        XCTAssertEqual(os, "iOS")
+        #elseif os(tvOS)
+        XCTAssertEqual(os, "tvOS")
+        #elseif os(watchOS)
+        XCTAssertEqual(os, "watchOS")
+        #elseif os(macOS)
+        XCTAssertEqual(os, "macOS")
+        #endif
+
+        XCTAssertFalse(osVersion.isEmpty)
+        XCTAssertFalse(name.isEmpty)
+    }
+}


### PR DESCRIPTION
Fixes test execution when run via `swift test` on GitHub. One of the tests in `BlueTriangleTests` depended on configuration from another test and `swift test` -- which is used to run the macOS test in the  test workflow -- executes tests in a different order than `xcodebuild ... test`.  Those tests have been made completely independent of one another.

This also adds `Decodable` conformance to `TimerRequest` in order to verify the performance monitoring sent in timer requests and splits testing of `Device` into a separate test case.