### PR TITLE
Enable Request Logging

### DIFF
--- a/Sources/BlueTriangle/BTLogger.swift
+++ b/Sources/BlueTriangle/BTLogger.swift
@@ -59,8 +59,10 @@ struct LoggerWrapper: SystemLogging {
 
 final class BTLogger: Logging {
     private let logger: SystemLogging
+    var enableDebug: Bool
 
-    init() {
+    init(enableDebug: Bool = false) {
+        self.enableDebug = enableDebug
         if #available(iOS 14.0, tvOS 14.0, watchOS 7.0, macOS 11.0, *) {
             self.logger = LoggerWrapper(subsystem: Constants.loggingSubsystem, category: Constants.loggingCategory)
         } else {

--- a/Sources/BlueTriangle/BTLogger.swift
+++ b/Sources/BlueTriangle/BTLogger.swift
@@ -68,6 +68,15 @@ final class BTLogger: Logging {
         }
     }
 
+    func logDebug(
+        _ message: @escaping () -> String,
+        file: StaticString,
+        function: StaticString,
+        line: UInt
+    ) {
+        logger.log(level: .debug, message: message, file: file, function: function, line: line)
+    }
+
     func logInfo(
         _ message: @escaping () -> String,
         file: StaticString,

--- a/Sources/BlueTriangle/BTLogger.swift
+++ b/Sources/BlueTriangle/BTLogger.swift
@@ -61,6 +61,11 @@ final class BTLogger: Logging {
     private let logger: SystemLogging
     var enableDebug: Bool
 
+    init(logger: SystemLogging, enableDebug: Bool) {
+        self.logger = logger
+        self.enableDebug = enableDebug
+    }
+
     init(enableDebug: Bool = false) {
         self.enableDebug = enableDebug
         if #available(iOS 14.0, tvOS 14.0, watchOS 7.0, macOS 11.0, *) {
@@ -76,7 +81,9 @@ final class BTLogger: Logging {
         function: StaticString,
         line: UInt
     ) {
-        logger.log(level: .debug, message: message, file: file, function: function, line: line)
+        if enableDebug {
+            logger.log(level: .debug, message: message, file: file, function: function, line: line)
+        }
     }
 
     func logInfo(

--- a/Sources/BlueTriangle/BlueTriangleConfiguration.swift
+++ b/Sources/BlueTriangle/BlueTriangleConfiguration.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+import os.log
 
 /// Configuration object for the Blue Triangle SDK.
 final public class BlueTriangleConfiguration: NSObject {
@@ -79,6 +80,9 @@ final public class BlueTriangleConfiguration: NSObject {
     /// Percentage of sessions for which network calls will be captured. A value of `0.05`
     /// means that 5% of sessions will be tracked.
     @objc public var networkSampleRate: Double = 0.05
+
+    /// Logging level.
+    @objc public var loggingLevel: OSLogType = .default
 
     var makeLogger: () -> Logging = {
         BTLogger.live

--- a/Sources/BlueTriangle/BlueTriangleConfiguration.swift
+++ b/Sources/BlueTriangle/BlueTriangleConfiguration.swift
@@ -6,7 +6,6 @@
 //
 
 import Foundation
-import os.log
 
 /// Configuration object for the Blue Triangle SDK.
 final public class BlueTriangleConfiguration: NSObject {
@@ -81,12 +80,8 @@ final public class BlueTriangleConfiguration: NSObject {
     /// means that 5% of sessions will be tracked.
     @objc public var networkSampleRate: Double = 0.05
 
-    /// Logging level.
-    @objc public var loggingLevel: OSLogType = .default
-
-    var makeLogger: () -> Logging = {
-        BTLogger.live
-    }
+    /// Boolean indicating whether debug logging is enabled.
+    @objc public var enableDebugLogging: Bool = false
 
     var timerConfiguration: BTTimer.Configuration = .live
 
@@ -132,6 +127,12 @@ extension BlueTriangleConfiguration {
                 dataCenter: dataCenter,
                 trafficSegmentName: trafficSegmentName
         )
+    }
+
+    func makeLogger () -> Logging {
+        var logger = BTLogger.live
+        logger.enableDebug = enableDebugLogging
+        return logger
     }
 
     func makePerformanceMonitorFactory() -> (() -> PerformanceMonitoring)? {

--- a/Sources/BlueTriangle/Extensions/Data+Utils.swift
+++ b/Sources/BlueTriangle/Extensions/Data+Utils.swift
@@ -1,0 +1,24 @@
+//
+//  Data+Utils.swift
+//
+//  Created by Mathew Gacy on 9/3/22.
+//  Copyright © 2022 Blue Triangle. All rights reserved.
+//
+
+import Foundation
+
+extension Data {
+    var prettyJson: String? {
+        guard let object = try? JSONSerialization.jsonObject(with: self, options: []),
+              let data = try? JSONSerialization.data(withJSONObject: object, options: [.prettyPrinted]),
+              let prettyPrintedString = String(data: data, encoding: .utf8) else {
+            return nil
+        }
+
+        return prettyPrintedString
+    }
+
+    func base64DecodedData(options: Data.Base64DecodingOptions = []) -> Data? {
+        Data(base64Encoded: self, options: options)
+    }
+}

--- a/Sources/BlueTriangle/Protocols/Logging.swift
+++ b/Sources/BlueTriangle/Protocols/Logging.swift
@@ -8,6 +8,13 @@
 import Foundation
 
 protocol Logging {
+    func logDebug(
+        _ message: @escaping () -> String,
+        file: StaticString,
+        function: StaticString,
+        line: UInt
+    )
+
     func logInfo(
         _ message: @escaping () -> String,
         file: StaticString,
@@ -24,6 +31,15 @@ protocol Logging {
 }
 
 extension Logging {
+    func debug(
+        _ message: @autoclosure @escaping () -> String,
+        file: StaticString = #fileID,
+        function: StaticString = #function,
+        line: UInt = #line
+    ) {
+        logDebug(message, file: file, function: function, line: line)
+    }
+
     func info(
         _ message: @autoclosure @escaping () -> String,
         file: StaticString = #fileID,

--- a/Sources/BlueTriangle/Protocols/Logging.swift
+++ b/Sources/BlueTriangle/Protocols/Logging.swift
@@ -39,9 +39,7 @@ extension Logging {
         function: StaticString = #function,
         line: UInt = #line
     ) {
-        if enableDebug {
-            logDebug(message, file: file, function: function, line: line)
-        }
+        logDebug(message, file: file, function: function, line: line)
     }
 
     func info(

--- a/Sources/BlueTriangle/Protocols/Logging.swift
+++ b/Sources/BlueTriangle/Protocols/Logging.swift
@@ -8,6 +8,8 @@
 import Foundation
 
 protocol Logging {
+    var enableDebug: Bool { get set }
+
     func logDebug(
         _ message: @escaping () -> String,
         file: StaticString,
@@ -37,7 +39,9 @@ extension Logging {
         function: StaticString = #function,
         line: UInt = #line
     ) {
-        logDebug(message, file: file, function: function, line: line)
+        if enableDebug {
+            logDebug(message, file: file, function: function, line: line)
+        }
     }
 
     func info(

--- a/Sources/BlueTriangle/Request.swift
+++ b/Sources/BlueTriangle/Request.swift
@@ -110,6 +110,6 @@ extension Request: Equatable {
 // MARK: - CustomStringConvertible
 extension Request: CustomStringConvertible {
     public var description: String {
-         "\(method) \(url.absoluteString) \(body != nil ? (String(data: body!, encoding: .utf8) ?? "") : "")"
+        "\(method) \(url.absoluteString) \(body != nil ? (body!.base64Decoded()?.prettyJson ?? "") : "")"
     }
 }

--- a/Sources/BlueTriangle/Request.swift
+++ b/Sources/BlueTriangle/Request.swift
@@ -110,6 +110,6 @@ extension Request: Equatable {
 // MARK: - CustomStringConvertible
 extension Request: CustomStringConvertible {
     public var description: String {
-        "\(method) \(url.absoluteString) \(body != nil ? (body!.base64Decoded()?.prettyJson ?? "") : "")"
+        "\(method.rawValue) \(url.absoluteString) \(body != nil ? ("\n\(body!.base64DecodedData()?.prettyJson ?? "")") : "")"
     }
 }

--- a/Sources/BlueTriangle/Request.swift
+++ b/Sources/BlueTriangle/Request.swift
@@ -25,6 +25,11 @@ struct Request: Codable, URLRequestConvertible {
     /// The data sent as the message body of a request, such as for an HTTP POST request.
     let body: Data?
 
+    /// The `URLQueryItem`s derived from ``parameters``.
+    var queryItems: [URLQueryItem]? {
+        parameters?.map { URLQueryItem(name: $0.0, value: $0.1) }
+    }
+
     /// Creates a request.
     /// - Parameters:
     ///   - method: The HTTP method for the request.
@@ -44,9 +49,9 @@ struct Request: Codable, URLRequestConvertible {
     /// - Returns: The URL request instance.
     func asURLRequest() -> URLRequest {
         var urlRequest: URLRequest
-        if let parameters = parameters, !parameters.isEmpty,
+        if let queryItems = queryItems,
            var components = URLComponents(url: url, resolvingAgainstBaseURL: true) {
-            components.queryItems = parameters.map { URLQueryItem(name: $0.0, value: $0.1) }
+            components.queryItems = queryItems
             urlRequest = URLRequest(url: components.url!)
         } else {
             urlRequest = URLRequest(url: url)
@@ -109,7 +114,30 @@ extension Request: Equatable {
 
 // MARK: - CustomStringConvertible
 extension Request: CustomStringConvertible {
+    var urlDescription: String {
+        if let queryItems = queryItems,
+           var components = URLComponents(url: url, resolvingAgainstBaseURL: true) {
+            components.queryItems = queryItems
+            return components.debugDescription
+        } else {
+            return url.absoluteString
+        }
+    }
+
     public var description: String {
-        "\(method.rawValue) \(url.absoluteString) \(body != nil ? ("\n\(body!.base64DecodedData()?.prettyJson ?? "")") : "")"
+        "\(method.rawValue) \(urlDescription) \(body != nil ? (String(data: body!, encoding: .utf8) ?? "") : "")"
+    }
+}
+
+// MARK: - CustomDebugStringConvertible
+extension Request: CustomDebugStringConvertible {
+    var debugBodyDescription: String? {
+        body?.base64DecodedData()?.prettyJson
+    }
+
+    public var debugDescription: String {
+        "Request:\n" +
+            "  \(method.rawValue) \(urlDescription) \n" +
+            "  Body: \(debugBodyDescription ?? "")"
     }
 }

--- a/Sources/BlueTriangle/Uploader.swift
+++ b/Sources/BlueTriangle/Uploader.swift
@@ -49,7 +49,7 @@ final class Uploader: Uploading {
     }
 
     func send(request: Request) {
-        logger.debug(request.description)
+        logger.debug(request.debugDescription)
         let id = UUID()
         let publisher = networking(request)
             .retry(retryConfiguration, scheduler: queue)

--- a/Sources/BlueTriangle/Uploader.swift
+++ b/Sources/BlueTriangle/Uploader.swift
@@ -49,6 +49,7 @@ final class Uploader: Uploading {
     }
 
     func send(request: Request) {
+        logger.debug(request.description)
         let id = UUID()
         let publisher = networking(request)
             .retry(retryConfiguration, scheduler: queue)

--- a/Tests/BlueTriangleTests/App/NetworkClientMock.swift
+++ b/Tests/BlueTriangleTests/App/NetworkClientMock.swift
@@ -124,7 +124,6 @@ extension MockRequest where ID == Int {
 extension MockRequest where ID == URL {
     static func makePhotoRequest(delayStrategy: DelayGenerator.Strategy, imageSize: CGSize) -> MockRequest<URL> {
         MockRequest(builder: { url in
-                        let id = Int(url.lastPathComponent) ?? 1
                         let color = UIColor.sampleColors.randomElement() ?? .brown
                         return color.pngData(imageSize)
                      },

--- a/Tests/BlueTriangleTests/BTLoggerTests.swift
+++ b/Tests/BlueTriangleTests/BTLoggerTests.swift
@@ -1,0 +1,34 @@
+//
+//  BTLoggerTests.swift
+//
+//  Created by Mathew Gacy on 9/8/22.
+//  Copyright © 2022 Blue Triangle. All rights reserved.
+//
+
+import XCTest
+import os.log
+@testable import BlueTriangle
+
+final class BTLoggerTests: XCTestCase {
+
+    func testDebugLogEnabled() throws {
+        let expectedMessage = "message"
+
+        let systemLogger = SystemLoggerMock { level, message in
+            XCTAssertEqual(level, .debug)
+            XCTAssertEqual(message, expectedMessage)
+        }
+
+        let logger = BTLogger(logger: systemLogger, enableDebug: true)
+        logger.debug(expectedMessage)
+    }
+
+    func testDebugLogDisabled() throws {
+        let systemLogger = SystemLoggerMock { level, message in
+            XCTFail("Unexpected debug message")
+        }
+
+        let logger = BTLogger(logger: systemLogger, enableDebug: false)
+        logger.debug("message")
+    }
+}

--- a/Tests/BlueTriangleTests/Mocks/LoggerMock.swift
+++ b/Tests/BlueTriangleTests/Mocks/LoggerMock.swift
@@ -9,12 +9,22 @@
 import Foundation
 
 class LoggerMock: Logging {
+    var onDebug: (String) -> Void
     var onInfo: (String) -> Void
     var onError: (String) -> Void
 
-    init(onInfo: @escaping (String) -> Void = { _ in }, onError: @escaping (String) -> Void = { _ in }) {
+    init(
+        onDebug: @escaping (String) -> Void = { _ in },
+        onInfo: @escaping (String) -> Void = { _ in },
+        onError: @escaping (String) -> Void = { _ in }
+    ) {
+        self.onDebug = onDebug
         self.onInfo = onInfo
         self.onError = onError
+    }
+
+    func logDebug(_ message: @autoclosure () -> String, file: StaticString, function: StaticString, line: UInt) {
+        onDebug(message())
     }
 
     func logInfo(_ message: @autoclosure () -> String, file: StaticString, function: StaticString, line: UInt) {

--- a/Tests/BlueTriangleTests/Mocks/LoggerMock.swift
+++ b/Tests/BlueTriangleTests/Mocks/LoggerMock.swift
@@ -9,22 +9,27 @@
 import Foundation
 
 class LoggerMock: Logging {
+    var enableDebug: Bool
     var onDebug: (String) -> Void
     var onInfo: (String) -> Void
     var onError: (String) -> Void
 
     init(
+        enableDebug: Bool = false,
         onDebug: @escaping (String) -> Void = { _ in },
         onInfo: @escaping (String) -> Void = { _ in },
         onError: @escaping (String) -> Void = { _ in }
     ) {
+        self.enableDebug = enableDebug
         self.onDebug = onDebug
         self.onInfo = onInfo
         self.onError = onError
     }
 
     func logDebug(_ message: @autoclosure () -> String, file: StaticString, function: StaticString, line: UInt) {
-        onDebug(message())
+        if enableDebug {
+            onDebug(message())
+        }
     }
 
     func logInfo(_ message: @autoclosure () -> String, file: StaticString, function: StaticString, line: UInt) {

--- a/Tests/BlueTriangleTests/Mocks/SystemLoggerMock.swift
+++ b/Tests/BlueTriangleTests/Mocks/SystemLoggerMock.swift
@@ -1,0 +1,29 @@
+//
+//  SystemLoggerMock.swift
+//
+//  Created by Mathew Gacy on 9/8/22.
+//  Copyright © 2022 Blue Triangle. All rights reserved.
+//
+
+import Foundation
+import XCTest
+import os.log
+@testable import BlueTriangle
+
+final class SystemLoggerMock: SystemLogging {
+    var onLog: (OSLogType, String) -> Void
+
+    init(onLog: @escaping (OSLogType, String) -> Void = { _, _ in }) {
+        self.onLog = onLog
+    }
+
+    func log(
+        level: OSLogType,
+        message: @escaping () -> String,
+        file: StaticString,
+        function: StaticString,
+        line: UInt
+    ) {
+        onLog(level, message())
+    }
+}

--- a/Tests/BlueTriangleTests/UploaderTests.swift
+++ b/Tests/BlueTriangleTests/UploaderTests.swift
@@ -129,7 +129,7 @@ final class UploaderTests: XCTestCase {
         waitForExpectations(timeout: 1.0)
     }
 
-    func testDebugLogIfEnabled() throws {
+    func testDebugLogging() throws {
         let logRequestExpectation = self.expectation(description: "Request logged")
         let completionExpectation = self.expectation(description: "Request finished")
 
@@ -158,10 +158,10 @@ final class UploaderTests: XCTestCase {
 
         uploader.send(request: Mock.request)
 
-        waitForExpectations(timeout: 1.0)
+        waitForExpectations(timeout: 0.1)
     }
 
-    func testDebugLogDisabled() throws {
+    func testSuccessLogging() throws {
         let completionExpectation = self.expectation(description: "Request finished")
         let logResponseExpectation = self.expectation(description: "Response logged")
 
@@ -175,10 +175,6 @@ final class UploaderTests: XCTestCase {
         }
 
         let logger = LoggerMock(
-            enableDebug: false,
-            onDebug: { _ in
-                XCTFail("Unexpected debug log")
-            },
             onInfo: { _ in
                 logResponseExpectation.fulfill()
             }
@@ -193,7 +189,7 @@ final class UploaderTests: XCTestCase {
 
         uploader.send(request: Mock.request)
 
-        waitForExpectations(timeout: 1.0)
+        waitForExpectations(timeout: 0.1)
     }
 
     func testUploaderSubscriptionRemoval() throws {
@@ -219,10 +215,7 @@ final class UploaderTests: XCTestCase {
                 }
             },
             onError: { _ in
-                responseCount += 1
-                if responseCount == requestCount * 2 {
-                    expectation.fulfill()
-                }
+                XCTFail("Unexpected Error")
             }
         )
 
@@ -247,7 +240,7 @@ final class UploaderTests: XCTestCase {
         }
 
         group.notify(queue: .main) {
-            print("SubscriptionCount: \(uploader.subscriptionCount)")
+            print("SubscriptionCount: \(uploader.subscriptionCount) - RequestCount: \(currentRequestCount) - ResponseCount: \(responseCount)")
             XCTAssert(uploader.subscriptionCount > requestCount)
         }
 


### PR DESCRIPTION
Enables debug logging of requests. Adds `BlueTriangleConfiguration.enableDebugLogging` and corresponding members to `Logging` that are used to optionally log requests sent to the Blue Triangle portal. Includes extensions on `Request` and `Data` that are used for formatting the logged requests.