### PR TITLE
Error Beacon Fixes

### DIFF
--- a/Sources/BlueTriangle/Constants.swift
+++ b/Sources/BlueTriangle/Constants.swift
@@ -30,6 +30,7 @@ enum Constants {
     static let eTp = "NativeAppCrash"
     static let crashReportFilename = "com.bluetriangle.crash"
     static let crashReportLineSeparator = "~~"
+    static let excludedValue = "20"
 
     // Logging
     static let loggingSubsystem = "com.bluetriangle.sdk"

--- a/Sources/BlueTriangle/CrashReportManager.swift
+++ b/Sources/BlueTriangle/CrashReportManager.swift
@@ -74,7 +74,8 @@ class CrashReportManager: CrashReportManaging {
                                  page: page,
                                  timer: timer,
                                  purchaseConfirmation: nil,
-                                 performanceReport: nil)
+                                 performanceReport: nil,
+                                 excluded: Constants.excludedValue)
 
         return try Request(method: .post,
                            url: Constants.timerEndpoint,

--- a/Sources/BlueTriangle/CrashReportManager.swift
+++ b/Sources/BlueTriangle/CrashReportManager.swift
@@ -68,7 +68,7 @@ class CrashReportManager: CrashReportManaging {
     }
 
     private func makeTimerRequest(session: Session, crashTime: Millisecond) throws -> Request {
-        let page = Page(deviceName: Device.name)
+        let page = Page(deviceName: Constants.crashID)
         let timer = PageTimeInterval(startTime: crashTime, interactiveTime: 0, pageTime: 0)
         let model = TimerRequest(session: session,
                                  page: page,

--- a/Sources/BlueTriangle/Models/TimerRequest.swift
+++ b/Sources/BlueTriangle/Models/TimerRequest.swift
@@ -13,6 +13,23 @@ struct TimerRequest: Equatable {
     let timer: PageTimeInterval
     let purchaseConfirmation: PurchaseConfirmation?
     let performanceReport: PerformanceReport?
+    let excluded: String?
+
+    init(
+        session: Session,
+        page: Page,
+        timer: PageTimeInterval,
+        purchaseConfirmation: PurchaseConfirmation? = nil,
+        performanceReport: PerformanceReport? = nil,
+        excluded: String? = nil
+    ) {
+        self.session = session
+        self.page = page
+        self.timer = timer
+        self.purchaseConfirmation = purchaseConfirmation
+        self.performanceReport = performanceReport
+        self.excluded = excluded
+    }
 }
 
 extension TimerRequest: Codable {
@@ -23,6 +40,7 @@ extension TimerRequest: Codable {
         try con.encode(Constants.browser, forKey: .browser)
         try con.encode(Version.number, forKey: .btV)
         try con.encode(Constants.device, forKey: .device)
+        try con.encodeIfPresent(excluded, forKey: .excluded)
         try con.encode(Constants.os, forKey: .os)
 
         // Session
@@ -231,6 +249,8 @@ extension TimerRequest: Codable {
         } else {
             self.performanceReport = nil
         }
+
+        self.excluded = try container.decodeIfPresent(String.self, forKey: .excluded)
     }
 
     enum CodingKeys: String, CodingKey {
@@ -238,6 +258,7 @@ extension TimerRequest: Codable {
         case browser
         case btV
         case device
+        case excluded
         case os
         // Session
         // swiftlint:disable:next identifier_name


### PR DESCRIPTION
Use `iOS Crash` as page name for crash error beacons and add `excluded` field to crash error beacons.