### PR TITLE
Expose Methods for Network Capture

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,15 +85,9 @@ BlueTriangle.endTimer(customTimer)
 
 ### Network Capture
 
-The Blue Triangle SDK offers `bt`-prefixed versions of common `URLSession` methods that can be used to gather information about network requests when network capture is enabled:
+The Blue Triangle SDK supports capturing network requests using either the `NetworkCaptureSessionDelegate` or `bt`-prefixed `URLSession` methods.
 
-| Standard                                       | Network Capture                                  |
-| :--                                            | :--                                              |
-| `URLSession.dataTask(with:completionHandler:)` | `URLSession.btDataTask(with:completionHandler:)` |
-| `URLSession.data(for:delegate:)`               | `URLSession.btData(for:delegate:)`               |
-| `URLSession.dataTaskPublisher(for:)`           | `URLSession.btDataTaskPublisher(for:)`           |
-
-To enable network capture, configure the SDK with a non-zero network sample rate:
+To enable network capture, first configure the SDK with a non-zero network sample rate:
 
 ```swift
 BlueTriangle.configure { config in
@@ -102,13 +96,39 @@ BlueTriangle.configure { config in
 }
 ```
 
-A value of `0.05`, for example, means that network capture will be randomly enabled for 5% of user sessions. Network requests made using one of the `bt`-prefixed `URLSession` methods will be associated with the last main timer to have been started.
+A value of `0.05`, for example, means that network capture will be randomly enabled for 5% of user sessions. Network requests using a `URLSession` with a `NetworkCaptureSessionDelegate` or made with one of the `bt`-prefixed `URLSession` methods will be associated with the last main timer to have been started at the time a request completes. Note that requests are only captured after at least one main timer has been started and they are not associated with a timer until the request ends.
+
+#### `NetworkCaptureSessionDelegate`
+
+You can use `NetworkCaptureSessionDelegate` or a subclass as your `URLSession` delegate to gather information about network requests when network capture is enabled:
+
+```swift
+let sesssion = URLSession(
+    configuration: .default,
+    delegate: NetworkCaptureSessionDelegate(),
+    delegateQueue: nil)
+
+let timer = BlueTriangle.startTimer(page: Page(pageName: "MY_PAGE"))
+...
+let (data, response) = try await session.data(from: URL(string: "https://example.com")!)
+```
+
+#### `URLSession` Methods
+
+Alternatively, use `bt`-prefixed `URLSession` methods to capture network requests:
+
+| Standard                                       | Network Capture                                  |
+| :--                                            | :--                                              |
+| `URLSession.dataTask(with:completionHandler:)` | `URLSession.btDataTask(with:completionHandler:)` |
+| `URLSession.data(for:delegate:)`               | `URLSession.btData(for:delegate:)`               |
+| `URLSession.dataTaskPublisher(for:)`           | `URLSession.btDataTaskPublisher(for:)`           |
+
+Use these methods just as you would their standard counterparts:
 
 ```swift
 let timer = BlueTriangle.startTimer(page: Page(pageName: "MY_PAGE"))
+...
 URLSession.shared.btDataTask(with: URL(string: "https://example.com")!) { data, response, error in
     // ...
 }.resume()
 ```
-
-Requests are not associated with a timer until the request ends.

--- a/Sources/BlueTriangle/BlueTriangle.swift
+++ b/Sources/BlueTriangle/BlueTriangle.swift
@@ -324,6 +324,14 @@ public extension BlueTriangle {
             await capturedRequestCollector?.collect(timer: timer, response: tuple.1)
         }
     }
+
+    /// Captures a network request.
+    /// - Parameter metrics: An object encapsulating the metrics for a session task.
+    static func captureRequest(metrics: URLSessionTaskMetrics) {
+        Task {
+            await capturedRequestCollector?.collect(metrics: metrics)
+        }
+    }
 }
 
 // MARK: - Crash Reporting

--- a/Sources/BlueTriangle/BlueTriangle.swift
+++ b/Sources/BlueTriangle/BlueTriangle.swift
@@ -283,8 +283,8 @@ public extension BlueTriangle {
 }
 
 // MARK: - Network Capture
-extension BlueTriangle {
-    static func timerDidStart(_ type: BTTimer.TimerType, page: Page, startTime: TimeInterval) {
+public extension BlueTriangle {
+    internal static func timerDidStart(_ type: BTTimer.TimerType, page: Page, startTime: TimeInterval) {
         guard case .main = type else {
             return
         }
@@ -294,7 +294,7 @@ extension BlueTriangle {
         }
     }
 
-    @usableFromInline
+    /// Returns a timer for network capture.
     static func startRequestTimer() -> InternalTimer? {
         guard shouldCaptureRequests else {
             return nil
@@ -304,14 +304,21 @@ extension BlueTriangle {
         return timer
     }
 
-    @usableFromInline
+    /// Captures a network request.
+    /// - Parameters:
+    ///   - timer: The request timer.
+    ///   - data: The request response data.
+    ///   - response: The request response.
     static func captureRequest(timer: InternalTimer, data: Data?, response: URLResponse?) {
         Task {
             await capturedRequestCollector?.collect(timer: timer, response: response)
         }
     }
 
-    @usableFromInline
+    /// Captures a network request.
+    /// - Parameters:
+    ///   - timer: The request timer.
+    ///   - tuple: The asynchronously-delivered tuple containing the request contents as a Data instance and a URLResponse.
     static func captureRequest(timer: InternalTimer, tuple: (Data, URLResponse)) {
         Task {
             await capturedRequestCollector?.collect(timer: timer, response: tuple.1)

--- a/Sources/BlueTriangle/Documentation.docc/NetworkCapture.md
+++ b/Sources/BlueTriangle/Documentation.docc/NetworkCapture.md
@@ -1,16 +1,8 @@
 # Network Capture
 
-Use `bt`-prefixed `URLSession` methods to gather information about network requests when network capture is enabled.
+The Blue Triangle SDK supports capturing network requests using either the `NetworkCaptureSessionDelegate` or `bt`-prefixed `URLSession` methods.
 
-The Blue Triangle SDK offers `bt`-prefixed versions of common `URLSession` methods that can be used to gather information about network requests when network capture is enabled:
-
-| Standard                                       | Network Capture                                  |
-| :--                                            | :--                                              |
-| `URLSession.dataTask(with:completionHandler:)` | `URLSession.btDataTask(with:completionHandler:)` |
-| `URLSession.data(for:delegate:)`               | `URLSession.btData(for:delegate:)`               |
-| `URLSession.dataTaskPublisher(for:)`           | `URLSession.btDataTaskPublisher(for:)`           |
-
-To enable network capture, configure the SDK with a non-zero network sample rate:
+To enable network capture, first configure the SDK with a non-zero network sample rate:
 
 ```swift
 BlueTriangle.configure { config in
@@ -19,10 +11,38 @@ BlueTriangle.configure { config in
 }
 ```
 
-A value of `0.05`, for example, means that network capture will be randomly enabled for 5% of user sessions. Network requests made using one of the `bt`-prefixed `URLSession` methods will be associated with the last main timer to have been started when a request completes:
+A value of `0.05`, for example, means that network capture will be randomly enabled for 5% of user sessions. Network requests using a `URLSession` with a `NetworkCaptureSessionDelegate` or made with one of the `bt`-prefixed `URLSession` methods will be associated with the last main timer to have been started at the time a request completes. Note that requests are not associated with a timer until the request ends.
+
+## `NetworkCaptureSessionDelegate`
+
+You can use `NetworkCaptureSessionDelegate` or a subclass as your `URLSession` delegate to gather information about network requests when network capture is enabled:
+
+```swift
+let sesssion = URLSession(
+    configuration: .default,
+    delegate: NetworkCaptureSessionDelegate(),
+    delegateQueue: nil)
+
+let timer = BlueTriangle.startTimer(page: Page(pageName: "MY_PAGE"))
+...
+let (data, response) = try await session.data(from: URL(string: "https://example.com")!)
+```
+
+## `URLSession` Methods
+
+Alternatively, use `bt`-prefixed `URLSession` methods to capture network requests:
+
+| Standard                                       | Network Capture                                  |
+| :--                                            | :--                                              |
+| `URLSession.dataTask(with:completionHandler:)` | `URLSession.btDataTask(with:completionHandler:)` |
+| `URLSession.data(for:delegate:)`               | `URLSession.btData(for:delegate:)`               |
+| `URLSession.dataTaskPublisher(for:)`           | `URLSession.btDataTaskPublisher(for:)`           |
+
+Use these methods just as you would their standard counterparts:
 
 ```swift
 let timer = BlueTriangle.startTimer(page: Page(pageName: "MY_PAGE"))
+...
 URLSession.shared.btDataTask(with: URL(string: "https://example.com")!) { data, response, error in
     // ...
 }.resume()

--- a/Sources/BlueTriangle/InternalTimer.swift
+++ b/Sources/BlueTriangle/InternalTimer.swift
@@ -39,8 +39,8 @@ public struct InternalTimer {
         handle(.start)
     }
 
-    @usableFromInline
-    mutating func end() {
+    /// Ends the timer.
+    public mutating func end() {
         handle(.end)
     }
 

--- a/Sources/BlueTriangle/InternalTimer.swift
+++ b/Sources/BlueTriangle/InternalTimer.swift
@@ -10,9 +10,13 @@ import Foundation
 /// An time that measures the duration of app events like network requuests.
 public struct InternalTimer {
 
-    enum State {
+    /// Describes the state of a timer.
+    public enum State {
+        /// Timer has not yet been started.
         case initial
+        /// Timer has been started.
         case started
+        /// Timer has been ended.
         case ended
     }
 
@@ -24,9 +28,18 @@ public struct InternalTimer {
     private let timeIntervalProvider: () -> TimeInterval
     private let logger: Logging
 
-    private(set) var state: State = .initial
-    private(set) var startTime: TimeInterval = 0.0
-    private(set) var endTime: TimeInterval = 0.0
+    /// The state of the timer.
+    public private(set) var state: State = .initial
+
+    /// The epoch time interval at which the timer was started.
+    ///
+    /// The default value is `0.0`.
+    public private(set) var startTime: TimeInterval = 0.0
+
+    /// The epoch time interval at which the timer was ended.
+    ///
+    /// The default value is `0.0`.
+    public private(set) var endTime: TimeInterval = 0.0
 
     init(logger: Logging,
          intervalProvider: @escaping () -> TimeInterval = { Date().timeIntervalSince1970 }

--- a/Sources/BlueTriangle/InternalTimer.swift
+++ b/Sources/BlueTriangle/InternalTimer.swift
@@ -7,8 +7,8 @@
 
 import Foundation
 
-@usableFromInline
-struct InternalTimer {
+/// An time that measures the duration of app events like network requuests.
+public struct InternalTimer {
 
     enum State {
         case initial
@@ -64,7 +64,7 @@ struct InternalTimer {
 
 // MARK: - CustomStringConvertible
 extension InternalTimer.State: CustomStringConvertible {
-    var description: String {
+    public var description: String {
         switch self {
         case .initial: return ".initial"
         case .started: return ".started"
@@ -74,7 +74,7 @@ extension InternalTimer.State: CustomStringConvertible {
 }
 
 extension InternalTimer: CustomStringConvertible {
-    @usableFromInline var description: String {
+    public var description: String {
         "InternalTimer(state: \(state), startTime: \(startTime), endTime: \(endTime))"
     }
 }

--- a/Sources/BlueTriangle/Models/CapturedRequest.swift
+++ b/Sources/BlueTriangle/Models/CapturedRequest.swift
@@ -129,6 +129,35 @@ extension CapturedRequest.InitiatorType {
 
 extension CapturedRequest {
     init(timer: InternalTimer, relativeTo startTime: Millisecond, response: URLResponse?) {
+        self.init(
+            startTime: timer.startTime.milliseconds - startTime,
+            endTime: timer.endTime.milliseconds - startTime,
+            duration: timer.endTime.milliseconds - timer.startTime.milliseconds,
+            decodedBodySize: response?.expectedContentLength ?? 0,
+            encodedBodySize: 0,
+            response: response)
+    }
+
+    init(metrics: URLSessionTaskMetrics, relativeTo startTime: Millisecond) {
+        let lastMetric = metrics.transactionMetrics.last
+
+        self.init(
+            startTime: metrics.taskInterval.start.timeIntervalSince1970.milliseconds - startTime,
+            endTime: metrics.taskInterval.end.timeIntervalSince1970.milliseconds - startTime,
+            duration: metrics.taskInterval.duration.milliseconds,
+            decodedBodySize: lastMetric?.countOfResponseBodyBytesAfterDecoding ?? 0,
+            encodedBodySize: lastMetric?.countOfResponseBodyBytesReceived ?? 0,
+            response: lastMetric?.response)
+    }
+
+    init(
+        startTime: Millisecond,
+        endTime: Millisecond,
+        duration: Millisecond,
+        decodedBodySize: Int64,
+        encodedBodySize: Int64,
+        response: URLResponse?
+    ) {
         let hostComponents = response?.url?.host?.split(separator: ".") ?? []
         self.host = hostComponents.first != nil ? String(hostComponents.first!) : ""
         if hostComponents.count > 2 {
@@ -148,11 +177,11 @@ extension CapturedRequest {
 
         self.url = response?.url?.absoluteString ?? ""
         self.file = response?.url?.lastPathComponent ?? ""
-        self.startTime = timer.startTime.milliseconds - startTime
-        self.endTime = timer.endTime.milliseconds - startTime
-        self.duration = timer.endTime.milliseconds - timer.startTime.milliseconds
-        self.decodedBodySize = 0
-        self.encodedBodySize = response?.expectedContentLength ?? 0
+        self.startTime = startTime
+        self.endTime = endTime
+        self.duration = duration
+        self.decodedBodySize = decodedBodySize
+        self.encodedBodySize = encodedBodySize
     }
 }
 

--- a/Sources/BlueTriangle/NetworkCapture/CapturedRequestCollector.swift
+++ b/Sources/BlueTriangle/NetworkCapture/CapturedRequestCollector.swift
@@ -54,6 +54,10 @@ actor CapturedRequestCollector: CapturedRequestCollecting {
         requestCollection?.insert(timer: timer, response: response)
     }
 
+    func collect(metrics: URLSessionTaskMetrics) {
+        requestCollection?.insert(metrics: metrics)
+    }
+
     // Use `nonisolated` to enable capture by timerManager handler.
     nonisolated private func batchRequests() {
         Task {

--- a/Sources/BlueTriangle/NetworkCapture/RequestCollection.swift
+++ b/Sources/BlueTriangle/NetworkCapture/RequestCollection.swift
@@ -26,6 +26,10 @@ struct RequestCollection: Equatable {
         requests.append(CapturedRequest(timer: timer, relativeTo: startTime, response: response))
     }
 
+    mutating func insert(metrics: URLSessionTaskMetrics) {
+        requests.append(CapturedRequest(metrics: metrics, relativeTo: startTime))
+    }
+
     mutating func batchRequests() -> [CapturedRequest]? {
         guard isNotEmpty else {
             return nil

--- a/Sources/BlueTriangle/NetworkCaptureSessionDelegate.swift
+++ b/Sources/BlueTriangle/NetworkCaptureSessionDelegate.swift
@@ -1,0 +1,26 @@
+//
+//  NetworkCaptureSessionDelegate.swift
+//
+//  Created by Mathew Gacy on 11/10/22.
+//  Copyright © 2022 Blue Triangle. All rights reserved.
+//
+
+import Foundation
+
+/// A session delegate that supports capturing network requests.
+open class NetworkCaptureSessionDelegate: NSObject, URLSessionTaskDelegate {
+
+    /// Tells the delegate that the session finished collecting metrics for the task.
+    ///
+    /// You can override this method to perform additional tasks associated with the collected
+    /// metrics. If you override this method, you must call `super` at some point in your
+    /// implementation.
+    ///
+    /// - Parameters:
+    ///   - session: The session collecting the metrics.
+    ///   - task: The task whose metrics have been collected.
+    ///   - metrics: The collected metrics.
+    open func urlSession(_ session: URLSession, task: URLSessionTask, didFinishCollecting metrics: URLSessionTaskMetrics) {
+        BlueTriangle.captureRequest(metrics: metrics)
+    }
+}

--- a/Sources/BlueTriangle/Protocols/CapturedRequestCollecting.swift
+++ b/Sources/BlueTriangle/Protocols/CapturedRequestCollecting.swift
@@ -10,4 +10,5 @@ import Foundation
 protocol CapturedRequestCollecting: Actor {
     func start(page: Page, startTime: TimeInterval)
     func collect(timer: InternalTimer, response: URLResponse?)
+    func collect(metrics: URLSessionTaskMetrics)
 }

--- a/Tests/BlueTriangleTests/Mocks/CapturedRequestCollectorMock.swift
+++ b/Tests/BlueTriangleTests/Mocks/CapturedRequestCollectorMock.swift
@@ -1,0 +1,37 @@
+//
+//  CapturedRequestCollectorMock.swift
+//
+//  Created by Mathew Gacy on 11/10/22.
+//  Copyright © 2022 Blue Triangle. All rights reserved.
+//
+
+@testable import BlueTriangle
+import Foundation
+
+actor CapturedRequestCollectorMock: CapturedRequestCollecting {
+    var onStart: (Page, TimeInterval) -> Void
+    var onCollectTimer: (InternalTimer, URLResponse?) -> Void
+    var onCollectMetrics: (URLSessionTaskMetrics) -> Void
+
+    init(
+        onStart: @escaping (Page, TimeInterval) -> Void = { _, _ in },
+        onCollectTimer: @escaping (InternalTimer, URLResponse?) -> Void = { _, _ in },
+        onCollectMetrics: @escaping (URLSessionTaskMetrics) -> Void = { _ in }
+    ) {
+        self.onStart = onStart
+        self.onCollectTimer = onCollectTimer
+        self.onCollectMetrics = onCollectMetrics
+    }
+
+    func start(page: Page, startTime: TimeInterval) {
+        onStart(page, startTime)
+    }
+
+    func collect(timer: InternalTimer, response: URLResponse?) {
+        onCollectTimer(timer, response)
+    }
+
+    func collect(metrics: URLSessionTaskMetrics) {
+        onCollectMetrics(metrics)
+    }
+}

--- a/Tests/BlueTriangleTests/Mocks/Mock.swift
+++ b/Tests/BlueTriangleTests/Mocks/Mock.swift
@@ -260,14 +260,14 @@ extension Mock {
             endTime: endTime,
             duration: endTime - startTime,
             initiatorType: .image,
-            decodedBodySize: 0,
-            encodedBodySize: 100)
+            decodedBodySize: 100,
+            encodedBodySize: 0)
     }
 }
 
 // MARK: - Request
 extension Mock {
-    static var capturedRequestJSON = "[{\"f\":\"foo.json\",\"ez\":-1,\"h\":\"example\",\"d\":1000,\"dz\":0,\"sT\":2000,\"e\":\"resource\",\"i\":\"other\",\"dmn\":\"example.com\",\"URL\":\"https:\\/\\/example.com\\/foo.json\",\"rE\":3000}]"
+    static var capturedRequestJSON = "[{\"f\":\"foo.json\",\"ez\":0,\"h\":\"example\",\"d\":1000,\"dz\":-1,\"sT\":2000,\"e\":\"resource\",\"i\":\"other\",\"dmn\":\"example.com\",\"URL\":\"https:\\/\\/example.com\\/foo.json\",\"rE\":3000}]"
 
     static func makeTimerRequestJSON(appVersion: String, os: String, osVersion: String, sdkVersion: String) -> String {
         """

--- a/Tests/BlueTriangleTests/Mocks/URLProtocolMock.swift
+++ b/Tests/BlueTriangleTests/Mocks/URLProtocolMock.swift
@@ -10,7 +10,7 @@ import XCTest
 
 final class URLProtocolMock: URLProtocol {
     static var responseQueue: DispatchQueue = .global()
-    static var responseDelay: TimeInterval? = 0.3
+    static var responseDelay: TimeInterval? = 0.1
     static var responseProvider: (URL) throws -> (Data, HTTPURLResponse) = { url in
         (Data(), Mock.makeHTTPResponse(url: url))
     }
@@ -43,6 +43,11 @@ final class URLProtocolMock: URLProtocol {
             client.urlProtocol(self, didFailWithError: error)
         }
         client.urlProtocolDidFinishLoading(self)
+    }
+
+    static func reset() {
+        responseDelay = 0.1
+        responseProvider = { (Data(), Mock.makeHTTPResponse(url: $0)) }
     }
 }
 

--- a/Tests/BlueTriangleTests/NetworkCaptureDelegateTests.swift
+++ b/Tests/BlueTriangleTests/NetworkCaptureDelegateTests.swift
@@ -1,0 +1,116 @@
+//
+//  NetworkCaptureDelegateTests.swift
+//
+//  Created by Mathew Gacy on 11/10/22.
+//  Copyright © 2022 Blue Triangle. All rights reserved.
+//
+
+@testable import BlueTriangle
+import XCTest
+
+final class NetworkCaptureDelegateTests: XCTestCase {
+
+    static func makeSession() -> URLSession {
+        URLSession(
+            configuration: .mock,
+            delegate: NetworkCaptureSessionDelegate(),
+            delegateQueue: nil)
+    }
+
+    override func tearDownWithError() throws {
+        URLProtocolMock.reset()
+    }
+
+    func testMetricsAreCapturedWithCompletionHandler() throws {
+        let metricsExpectation = expectation(description: "Collected session task metrics")
+        var metrics: URLSessionTaskMetrics!
+        let requestCollector = CapturedRequestCollectorMock(onCollectMetrics: { taskMetrics in
+            metrics = taskMetrics
+            metricsExpectation.fulfill()
+        })
+
+        let configuration = BlueTriangleConfiguration()
+        Mock.configureBlueTriangle(configuration: configuration)
+
+        // Configure Blue Triangle
+        BlueTriangle.reconfigure(
+            configuration: configuration,
+            logger: LoggerMock(),
+            uploader: UploaderMock(),
+            shouldCaptureRequests: true,
+            requestCollector: requestCollector
+        )
+
+        let resourceURL: URL = "https://example.com"
+        let response = Mock.makeHTTPResponse(
+            url: resourceURL,
+            headerFields: ["Content-Type": "application/json"])
+
+        URLProtocolMock.responseProvider = { _ in
+            (Mock.successJSON, response)
+        }
+
+        // Start timer for network capture
+        _ = BlueTriangle.startTimer(page: Page(pageName: "Example"))
+
+        // Request to capture
+        let session = Self.makeSession()
+
+        let responseExpectation = expectation(description: "Received response")
+        session.dataTask(with: resourceURL) { data, response, error in
+            responseExpectation.fulfill()
+        }.resume()
+
+        waitForExpectations(timeout: 1, handler: nil)
+
+        XCTAssert(metrics.taskInterval.start.timeIntervalSince1970 > 0)
+        XCTAssert(metrics.taskInterval.end.timeIntervalSince1970 > 0)
+        XCTAssert(metrics.taskInterval.duration > 0)
+    }
+
+    func testMetricsAreCapturedWithAsync() async throws {
+        let metricsExpectation = expectation(description: "Collected session task metrics")
+        var metrics: URLSessionTaskMetrics!
+        let requestCollector = CapturedRequestCollectorMock(onCollectMetrics: { taskMetrics in
+            metrics = taskMetrics
+            metricsExpectation.fulfill()
+        })
+
+        let configuration = BlueTriangleConfiguration()
+        Mock.configureBlueTriangle(configuration: configuration)
+
+        // Configure Blue Triangle
+        BlueTriangle.reconfigure(
+            configuration: configuration,
+            logger: LoggerMock(),
+            uploader: UploaderMock(),
+            shouldCaptureRequests: true,
+            requestCollector: requestCollector
+        )
+
+        let resourceURL: URL = "https://example.com"
+        let response = Mock.makeHTTPResponse(
+            url: resourceURL,
+            headerFields: ["Content-Type": "application/json"])
+
+        URLProtocolMock.responseProvider = { _ in
+            (Mock.successJSON, response)
+        }
+
+        // Start timer for network capture
+        _ = BlueTriangle.startTimer(page: Page(pageName: "Example"))
+
+        // Request to capture
+        let session = Self.makeSession()
+
+        let responseExpectation = expectation(description: "Received response")
+        _ = try await session.data(from: resourceURL)
+        responseExpectation.fulfill()
+
+        await waitForExpectations(timeout: 1)
+
+        XCTAssert(metrics.taskInterval.start.timeIntervalSince1970 > 0)
+        XCTAssert(metrics.taskInterval.end.timeIntervalSince1970 > 0)
+        XCTAssert(metrics.taskInterval.duration > 0)
+    }
+}


### PR DESCRIPTION
Enables custom implementations of network capture by making the methods to create a network request timer and capture a response public and adds documentation.

Usage:

```swift
// Before making request
let timer = BlueTriangle.startRequestTimer()

... make request; receive `Data`, `URLResponse`

if var timer = timer {
    timer.end()
    BlueTriangle.captureRequest(timer: timer, data: data, response: response)
}
```