### PR TITLE
Configurable Task Priority to Fix CI Issues

### DIFF
--- a/Sources/BlueTriangle/NetworkCapture/CapturedRequestCollector.swift
+++ b/Sources/BlueTriangle/NetworkCapture/CapturedRequestCollector.swift
@@ -12,6 +12,7 @@ actor CapturedRequestCollector: CapturedRequestCollecting {
     private var timerManager: CaptureTimerManaging
     private let requestBuilder: CapturedRequestBuilder
     private let uploader: Uploading
+    private let uploadTaskPriority: TaskPriority
     private var requestCollection: RequestCollection?
     private(set) var hasBeenConfigured: Bool = false
 
@@ -19,12 +20,14 @@ actor CapturedRequestCollector: CapturedRequestCollecting {
         logger: Logging,
         timerManager: CaptureTimerManaging,
         requestBuilder: CapturedRequestBuilder,
-        uploader: Uploading
+        uploader: Uploading,
+        uploadTaskPriority: TaskPriority = .background
     ) {
         self.logger = logger
         self.timerManager = timerManager
         self.requestBuilder = requestBuilder
         self.uploader = uploader
+        self.uploadTaskPriority = uploadTaskPriority
     }
 
     func configure() {
@@ -70,7 +73,7 @@ actor CapturedRequestCollector: CapturedRequestCollecting {
     }
 
     private func upload(startTime: Millisecond, page: Page, requests: [CapturedRequest]) {
-        Task.detached(priority: .background) {
+        Task.detached(priority: uploadTaskPriority) {
             do {
                 let request = try self.requestBuilder.build(startTime, page, requests)
                 self.uploader.send(request: request)

--- a/Tests/BlueTriangleTests/RequestCollectorTests.swift
+++ b/Tests/BlueTriangleTests/RequestCollectorTests.swift
@@ -22,6 +22,8 @@ class RequestCollectorTests: XCTestCase {
     }
 
     let uploadTaskPriority: TaskPriority = .high
+    let shortTimeout: TimeInterval = 0.2
+    let longTimeout: TimeInterval = 1.0
 
     override class func tearDown() {
         BlueTriangle.reset()
@@ -67,8 +69,8 @@ class RequestCollectorTests: XCTestCase {
 
         await collector.start(page: Mock.page, startTime: 1.0)
 
-        wait(for: [cancelExpectation!], timeout: 0.1)
-        wait(for: [startExpectation], timeout: 0.1)
+        wait(for: [cancelExpectation!], timeout: shortTimeout)
+        wait(for: [startExpectation], timeout: shortTimeout)
         // Accommodate timer manager cancel on deinit
         cancelExpectation = nil
     }
@@ -114,7 +116,7 @@ class RequestCollectorTests: XCTestCase {
         // Start another timer
         await collector.start(page: Page(pageName: "Another_Page"), startTime: 2.0)
 
-        wait(for: [requestExpectation, uploadExpectation], timeout: 1.0)
+        wait(for: [requestExpectation, uploadExpectation], timeout: longTimeout)
 
         XCTAssertEqual(actualStartTime, expectedStartTime.milliseconds)
         XCTAssertEqual(actualPage, expectedPage)
@@ -194,7 +196,7 @@ class RequestCollectorTests: XCTestCase {
         timerManager.fireTimer()
 
         try await Task.sleep(nanoseconds: 1.0.nanoseconds)
-        wait(for: [requestExpectation, uploadExpectation], timeout: 1.0)
+        wait(for: [requestExpectation, uploadExpectation], timeout: longTimeout)
 
         XCTAssertEqual(actualStartTime, expectedStartTime.milliseconds)
         XCTAssertEqual(actualPage, expectedPage)
@@ -232,7 +234,7 @@ class RequestCollectorTests: XCTestCase {
         timerManager.fireTimer()
 
         try await Task.sleep(nanoseconds: 1.0.nanoseconds)
-        wait(for: [requestExpectation, uploadExpectation], timeout: 1.0)
+        wait(for: [requestExpectation, uploadExpectation], timeout: longTimeout)
     }
 
     func testRequestBuilderError() async throws {
@@ -268,7 +270,7 @@ class RequestCollectorTests: XCTestCase {
 
         await collector.start(page: Page(pageName: "Another_Page"), startTime: 2.0)
 
-        wait(for: [logErrorExpectation], timeout: 1.0)
+        wait(for: [logErrorExpectation], timeout: longTimeout)
     }
 
     func testMultipleConfigureCalls() async throws {
@@ -314,7 +316,7 @@ class RequestCollectorTests: XCTestCase {
         timerManager.fireTimer()
 
         try await Task.sleep(nanoseconds: 1.0.nanoseconds)
-        wait(for: [requestExpectation, uploadExpectation], timeout: 1.0)
+        wait(for: [requestExpectation, uploadExpectation], timeout: longTimeout)
 
         XCTAssertEqual(actualStartTime, expectedStartTime.milliseconds)
         XCTAssertEqual(actualPage, expectedPage)

--- a/Tests/BlueTriangleTests/RequestCollectorTests.swift
+++ b/Tests/BlueTriangleTests/RequestCollectorTests.swift
@@ -21,6 +21,8 @@ class RequestCollectorTests: XCTestCase {
         return Request(method: .post, url: Constants.capturedRequestEndpoint)
     }
 
+    let uploadTaskPriority: TaskPriority = .high
+
     override class func tearDown() {
         BlueTriangle.reset()
     }
@@ -59,7 +61,8 @@ class RequestCollectorTests: XCTestCase {
             logger: Self.logger,
             timerManager: timerManager,
             requestBuilder: Self.requestBuilder,
-            uploader: UploaderMock())
+            uploader: UploaderMock(),
+            uploadTaskPriority: uploadTaskPriority)
         await collector.configure()
 
         await collector.start(page: Mock.page, startTime: 1.0)
@@ -92,7 +95,8 @@ class RequestCollectorTests: XCTestCase {
             logger: Self.logger,
             timerManager: CaptureTimerManagerMock(),
             requestBuilder: requestBuilder,
-            uploader: uploader)
+            uploader: uploader,
+            uploadTaskPriority: uploadTaskPriority)
         await collector.configure()
 
         // Start BTTimer
@@ -135,7 +139,8 @@ class RequestCollectorTests: XCTestCase {
             logger: Self.logger,
             timerManager: CaptureTimerManagerMock(),
             requestBuilder: requestBuilder,
-            uploader: uploader)
+            uploader: uploader,
+            uploadTaskPriority: uploadTaskPriority)
         await collector.configure()
 
         // Start BTTimer
@@ -170,7 +175,8 @@ class RequestCollectorTests: XCTestCase {
             logger: Self.logger,
             timerManager: timerManager,
             requestBuilder: requestBuilder,
-            uploader: uploader)
+            uploader: uploader,
+            uploadTaskPriority: uploadTaskPriority)
         await collector.configure()
 
         // Start BTTimer
@@ -214,7 +220,8 @@ class RequestCollectorTests: XCTestCase {
             logger: Self.logger,
             timerManager: timerManager,
             requestBuilder: requestBuilder,
-            uploader: uploader)
+            uploader: uploader,
+            uploadTaskPriority: uploadTaskPriority)
         await collector.configure()
 
         // Start BTTimer
@@ -245,7 +252,8 @@ class RequestCollectorTests: XCTestCase {
             logger: logger,
             timerManager: timerManager,
             requestBuilder: requestBuilder,
-            uploader: UploaderMock())
+            uploader: UploaderMock(),
+            uploadTaskPriority: uploadTaskPriority)
         await collector.configure()
 
         // Start BTTimer
@@ -286,7 +294,8 @@ class RequestCollectorTests: XCTestCase {
             logger: Self.logger,
             timerManager: timerManager,
             requestBuilder: requestBuilder,
-            uploader: uploader)
+            uploader: uploader,
+            uploadTaskPriority: uploadTaskPriority)
         await collector.configure()
         await collector.configure()
 


### PR DESCRIPTION
Given the limited resources of the GitHub runners, expectations are timing out when awaiting tasks performed with a `background` priority in the iOS simulator. This enables configuration of `CapturedRequestCollector`'s upload task priority so that it can be elevated in tests.

This also adds members on `RequestCollectorTests` for the timeout values used when awaiting expectations to make it easier to increase these values if needed in the future.