### PR TITLE
Add NetworkCaptureSessionDelegate

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ BlueTriangle.endTimer(customTimer)
 
 The Blue Triangle SDK supports capturing network requests using either the `NetworkCaptureSessionDelegate` or `bt`-prefixed `URLSession` methods.
 
-To enable network capture, configure the SDK with a non-zero network sample rate:
+To enable network capture, first configure the SDK with a non-zero network sample rate:
 
 ```swift
 BlueTriangle.configure { config in
@@ -96,11 +96,11 @@ BlueTriangle.configure { config in
 }
 ```
 
-A value of `0.05`, for example, means that network capture will be randomly enabled for 5% of user sessions. Network requests using a `URLSession` with a `NetworkCaptureSessionDelegate` or made with one of the `bt`-prefixed `URLSession` methods will be associated with the last main timer to have been started at the time a request completes. Note that requests are not associated with a timer until the request ends.
+A value of `0.05`, for example, means that network capture will be randomly enabled for 5% of user sessions. Network requests using a `URLSession` with a `NetworkCaptureSessionDelegate` or made with one of the `bt`-prefixed `URLSession` methods will be associated with the last main timer to have been started at the time a request completes. Note that requests are only captured after at least one main timer has been started and they are not associated with a timer until the request ends.
 
 #### `NetworkCaptureSessionDelegate`
 
-Use `NetworkCaptureSessionDelegate` as your `URLSession` delegate to gather information about network requests when network capture is enabled.
+You can use `NetworkCaptureSessionDelegate` or a subclass as your `URLSession` delegate to gather information about network requests when network capture is enabled:
 
 ```swift
 let sesssion = URLSession(
@@ -108,14 +108,14 @@ let sesssion = URLSession(
     delegate: NetworkCaptureSessionDelegate(),
     delegateQueue: nil)
 
+let timer = BlueTriangle.startTimer(page: Page(pageName: "MY_PAGE"))
+...
 let (data, response) = try await session.data(from: URL(string: "https://example.com")!)
 ```
 
 #### `URLSession` Methods
 
-Use `bt`-prefixed `URLSession` methods to gather information about network requests when network capture is enabled.
-
-The Blue Triangle SDK offers `bt`-prefixed versions of common `URLSession` methods that can be used to capture network requests:
+Alternatively, use `bt`-prefixed `URLSession` methods to capture network requests:
 
 | Standard                                       | Network Capture                                  |
 | :--                                            | :--                                              |
@@ -127,6 +127,7 @@ Use these methods just as you would their standard counterparts:
 
 ```swift
 let timer = BlueTriangle.startTimer(page: Page(pageName: "MY_PAGE"))
+...
 URLSession.shared.btDataTask(with: URL(string: "https://example.com")!) { data, response, error in
     // ...
 }.resume()

--- a/README.md
+++ b/README.md
@@ -85,13 +85,7 @@ BlueTriangle.endTimer(customTimer)
 
 ### Network Capture
 
-The Blue Triangle SDK offers `bt`-prefixed versions of common `URLSession` methods that can be used to gather information about network requests when network capture is enabled:
-
-| Standard                                       | Network Capture                                  |
-| :--                                            | :--                                              |
-| `URLSession.dataTask(with:completionHandler:)` | `URLSession.btDataTask(with:completionHandler:)` |
-| `URLSession.data(for:delegate:)`               | `URLSession.btData(for:delegate:)`               |
-| `URLSession.dataTaskPublisher(for:)`           | `URLSession.btDataTaskPublisher(for:)`           |
+The Blue Triangle SDK supports capturing network requests using either the `NetworkCaptureSessionDelegate` or `bt`-prefixed `URLSession` methods.
 
 To enable network capture, configure the SDK with a non-zero network sample rate:
 
@@ -102,7 +96,34 @@ BlueTriangle.configure { config in
 }
 ```
 
-A value of `0.05`, for example, means that network capture will be randomly enabled for 5% of user sessions. Network requests made using one of the `bt`-prefixed `URLSession` methods will be associated with the last main timer to have been started.
+A value of `0.05`, for example, means that network capture will be randomly enabled for 5% of user sessions. Network requests using a `URLSession` with a `NetworkCaptureSessionDelegate` or made with one of the `bt`-prefixed `URLSession` methods will be associated with the last main timer to have been started at the time a request completes. Note that requests are not associated with a timer until the request ends.
+
+#### `NetworkCaptureSessionDelegate`
+
+Use `NetworkCaptureSessionDelegate` as your `URLSession` delegate to gather information about network requests when network capture is enabled.
+
+```swift
+let sesssion = URLSession(
+    configuration: .default,
+    delegate: NetworkCaptureSessionDelegate(),
+    delegateQueue: nil)
+
+let (data, response) = try await session.data(from: URL(string: "https://example.com")!)
+```
+
+#### `URLSession` Methods
+
+Use `bt`-prefixed `URLSession` methods to gather information about network requests when network capture is enabled.
+
+The Blue Triangle SDK offers `bt`-prefixed versions of common `URLSession` methods that can be used to capture network requests:
+
+| Standard                                       | Network Capture                                  |
+| :--                                            | :--                                              |
+| `URLSession.dataTask(with:completionHandler:)` | `URLSession.btDataTask(with:completionHandler:)` |
+| `URLSession.data(for:delegate:)`               | `URLSession.btData(for:delegate:)`               |
+| `URLSession.dataTaskPublisher(for:)`           | `URLSession.btDataTaskPublisher(for:)`           |
+
+Use these methods just as you would their standard counterparts:
 
 ```swift
 let timer = BlueTriangle.startTimer(page: Page(pageName: "MY_PAGE"))
@@ -110,5 +131,3 @@ URLSession.shared.btDataTask(with: URL(string: "https://example.com")!) { data, 
     // ...
 }.resume()
 ```
-
-Requests are not associated with a timer until the request ends.

--- a/Sources/BlueTriangle/BlueTriangle.swift
+++ b/Sources/BlueTriangle/BlueTriangle.swift
@@ -324,6 +324,14 @@ public extension BlueTriangle {
             await capturedRequestCollector?.collect(timer: timer, response: tuple.1)
         }
     }
+
+    /// Captures a network request.
+    /// - Parameter metrics: An object encapsulating the metrics for a session task.
+    static func captureRequest(metrics: URLSessionTaskMetrics) {
+        Task {
+            await capturedRequestCollector?.collect(metrics: metrics)
+        }
+    }
 }
 
 // MARK: - Crash Reporting

--- a/Sources/BlueTriangle/Documentation.docc/NetworkCapture.md
+++ b/Sources/BlueTriangle/Documentation.docc/NetworkCapture.md
@@ -1,14 +1,6 @@
 # Network Capture
 
-Use `bt`-prefixed `URLSession` methods to gather information about network requests when network capture is enabled.
-
-The Blue Triangle SDK offers `bt`-prefixed versions of common `URLSession` methods that can be used to gather information about network requests when network capture is enabled:
-
-| Standard                                       | Network Capture                                  |
-| :--                                            | :--                                              |
-| `URLSession.dataTask(with:completionHandler:)` | `URLSession.btDataTask(with:completionHandler:)` |
-| `URLSession.data(for:delegate:)`               | `URLSession.btData(for:delegate:)`               |
-| `URLSession.dataTaskPublisher(for:)`           | `URLSession.btDataTaskPublisher(for:)`           |
+The Blue Triangle SDK supports capturing network requests using either the `NetworkCaptureSessionDelegate` or `bt`-prefixed `URLSession` methods.
 
 To enable network capture, configure the SDK with a non-zero network sample rate:
 
@@ -19,7 +11,35 @@ BlueTriangle.configure { config in
 }
 ```
 
-A value of `0.05`, for example, means that network capture will be randomly enabled for 5% of user sessions. Network requests made using one of the `bt`-prefixed `URLSession` methods will be associated with the last main timer to have been started when a request completes:
+A value of `0.05`, for example, means that network capture will be randomly enabled for 5% of user sessions. Network requests using a `URLSession` with a `NetworkCaptureSessionDelegate` or made with one of the `bt`-prefixed `URLSession` methods will be associated with the last main timer to have been started at the time a request completes. Note that requests are not associated with a timer until the request ends.
+
+## `NetworkCaptureSessionDelegate`
+
+Use `NetworkCaptureSessionDelegate` as your `URLSession` delegate to gather information about network requests when network capture is enabled.
+
+```swift
+let sesssion = URLSession(
+    configuration: .default,
+    delegate: NetworkCaptureSessionDelegate(),
+    delegateQueue: nil)
+
+let (data, response) = try await session.data(from: URL(string: "https://example.com")!)
+```
+
+
+## `URLSession` Methods
+
+Use `bt`-prefixed `URLSession` methods to gather information about network requests when network capture is enabled.
+
+The Blue Triangle SDK offers `bt`-prefixed versions of common `URLSession` methods that can be used to capture network requests:
+
+| Standard                                       | Network Capture                                  |
+| :--                                            | :--                                              |
+| `URLSession.dataTask(with:completionHandler:)` | `URLSession.btDataTask(with:completionHandler:)` |
+| `URLSession.data(for:delegate:)`               | `URLSession.btData(for:delegate:)`               |
+| `URLSession.dataTaskPublisher(for:)`           | `URLSession.btDataTaskPublisher(for:)`           |
+
+Use these methods just as you would their standard counterparts:
 
 ```swift
 let timer = BlueTriangle.startTimer(page: Page(pageName: "MY_PAGE"))
@@ -27,3 +47,4 @@ URLSession.shared.btDataTask(with: URL(string: "https://example.com")!) { data, 
     // ...
 }.resume()
 ```
+

--- a/Sources/BlueTriangle/Documentation.docc/NetworkCapture.md
+++ b/Sources/BlueTriangle/Documentation.docc/NetworkCapture.md
@@ -2,7 +2,7 @@
 
 The Blue Triangle SDK supports capturing network requests using either the `NetworkCaptureSessionDelegate` or `bt`-prefixed `URLSession` methods.
 
-To enable network capture, configure the SDK with a non-zero network sample rate:
+To enable network capture, first configure the SDK with a non-zero network sample rate:
 
 ```swift
 BlueTriangle.configure { config in
@@ -15,7 +15,7 @@ A value of `0.05`, for example, means that network capture will be randomly enab
 
 ## `NetworkCaptureSessionDelegate`
 
-Use `NetworkCaptureSessionDelegate` as your `URLSession` delegate to gather information about network requests when network capture is enabled.
+You can use `NetworkCaptureSessionDelegate` or a subclass as your `URLSession` delegate to gather information about network requests when network capture is enabled:
 
 ```swift
 let sesssion = URLSession(
@@ -23,15 +23,14 @@ let sesssion = URLSession(
     delegate: NetworkCaptureSessionDelegate(),
     delegateQueue: nil)
 
+let timer = BlueTriangle.startTimer(page: Page(pageName: "MY_PAGE"))
+...
 let (data, response) = try await session.data(from: URL(string: "https://example.com")!)
 ```
 
-
 ## `URLSession` Methods
 
-Use `bt`-prefixed `URLSession` methods to gather information about network requests when network capture is enabled.
-
-The Blue Triangle SDK offers `bt`-prefixed versions of common `URLSession` methods that can be used to capture network requests:
+Alternatively, use `bt`-prefixed `URLSession` methods to capture network requests:
 
 | Standard                                       | Network Capture                                  |
 | :--                                            | :--                                              |
@@ -43,8 +42,8 @@ Use these methods just as you would their standard counterparts:
 
 ```swift
 let timer = BlueTriangle.startTimer(page: Page(pageName: "MY_PAGE"))
+...
 URLSession.shared.btDataTask(with: URL(string: "https://example.com")!) { data, response, error in
     // ...
 }.resume()
 ```
-

--- a/Sources/BlueTriangle/Models/CapturedRequest.swift
+++ b/Sources/BlueTriangle/Models/CapturedRequest.swift
@@ -133,8 +133,8 @@ extension CapturedRequest {
             startTime: timer.startTime.milliseconds - startTime,
             endTime: timer.endTime.milliseconds - startTime,
             duration: timer.endTime.milliseconds - timer.startTime.milliseconds,
-            decodedBodySize: 0,
-            encodedBodySize: response?.expectedContentLength ?? 0,
+            decodedBodySize: response?.expectedContentLength ?? 0,
+            encodedBodySize: 0,
             response: response)
     }
 

--- a/Sources/BlueTriangle/Models/CapturedRequest.swift
+++ b/Sources/BlueTriangle/Models/CapturedRequest.swift
@@ -138,12 +138,12 @@ extension CapturedRequest {
             response: response)
     }
 
-    init(metrics: URLSessionTaskMetrics) {
+    init(metrics: URLSessionTaskMetrics, relativeTo startTime: Millisecond) {
         let lastMetric = metrics.transactionMetrics.last
 
         self.init(
-            startTime: metrics.taskInterval.start.timeIntervalSince1970.milliseconds,
-            endTime: metrics.taskInterval.end.timeIntervalSince1970.milliseconds,
+            startTime: metrics.taskInterval.start.timeIntervalSince1970.milliseconds - startTime,
+            endTime: metrics.taskInterval.end.timeIntervalSince1970.milliseconds - startTime,
             duration: metrics.taskInterval.duration.milliseconds,
             decodedBodySize: lastMetric?.countOfResponseBodyBytesAfterDecoding ?? 0,
             encodedBodySize: lastMetric?.countOfResponseBodyBytesReceived ?? 0,

--- a/Sources/BlueTriangle/NetworkCapture/CapturedRequestCollector.swift
+++ b/Sources/BlueTriangle/NetworkCapture/CapturedRequestCollector.swift
@@ -54,6 +54,10 @@ actor CapturedRequestCollector: CapturedRequestCollecting {
         requestCollection?.insert(timer: timer, response: response)
     }
 
+    func collect(metrics: URLSessionTaskMetrics) {
+        requestCollection?.insert(metrics: metrics)
+    }
+
     // Use `nonisolated` to enable capture by timerManager handler.
     nonisolated private func batchRequests() {
         Task {

--- a/Sources/BlueTriangle/NetworkCapture/RequestCollection.swift
+++ b/Sources/BlueTriangle/NetworkCapture/RequestCollection.swift
@@ -26,6 +26,9 @@ struct RequestCollection: Equatable {
         requests.append(CapturedRequest(timer: timer, relativeTo: startTime, response: response))
     }
 
+    mutating func insert(metrics: URLSessionTaskMetrics) {
+    }
+
     mutating func batchRequests() -> [CapturedRequest]? {
         guard isNotEmpty else {
             return nil

--- a/Sources/BlueTriangle/NetworkCapture/RequestCollection.swift
+++ b/Sources/BlueTriangle/NetworkCapture/RequestCollection.swift
@@ -27,6 +27,7 @@ struct RequestCollection: Equatable {
     }
 
     mutating func insert(metrics: URLSessionTaskMetrics) {
+        requests.append(CapturedRequest(metrics: metrics))
     }
 
     mutating func batchRequests() -> [CapturedRequest]? {

--- a/Sources/BlueTriangle/NetworkCapture/RequestCollection.swift
+++ b/Sources/BlueTriangle/NetworkCapture/RequestCollection.swift
@@ -27,7 +27,7 @@ struct RequestCollection: Equatable {
     }
 
     mutating func insert(metrics: URLSessionTaskMetrics) {
-        requests.append(CapturedRequest(metrics: metrics))
+        requests.append(CapturedRequest(metrics: metrics, relativeTo: startTime))
     }
 
     mutating func batchRequests() -> [CapturedRequest]? {

--- a/Sources/BlueTriangle/NetworkCaptureSessionDelegate.swift
+++ b/Sources/BlueTriangle/NetworkCaptureSessionDelegate.swift
@@ -16,8 +16,6 @@ open class NetworkCaptureSessionDelegate: NSObject, URLSessionTaskDelegate {
     ///   - task: The task whose metrics have been collected.
     ///   - metrics: The collected metrics.
     open func urlSession(_ session: URLSession, task: URLSessionTask, didFinishCollecting metrics: URLSessionTaskMetrics) {
-//        print("\(#function): \(metrics)")
-        print("\(#function)")
         BlueTriangle.captureRequest(metrics: metrics)
     }
 }

--- a/Sources/BlueTriangle/NetworkCaptureSessionDelegate.swift
+++ b/Sources/BlueTriangle/NetworkCaptureSessionDelegate.swift
@@ -1,0 +1,23 @@
+//
+//  NetworkCaptureSessionDelegate.swift
+//
+//  Created by Mathew Gacy on 11/10/22.
+//  Copyright © 2022 Blue Triangle. All rights reserved.
+//
+
+import Foundation
+
+/// A session delegate that supports capturing network requests.
+open class NetworkCaptureSessionDelegate: NSObject, URLSessionTaskDelegate {
+
+    /// Tells the delegate that the session finished collecting metrics for the task.
+    /// - Parameters:
+    ///   - session: The session collecting the metrics.
+    ///   - task: The task whose metrics have been collected.
+    ///   - metrics: The collected metrics.
+    open func urlSession(_ session: URLSession, task: URLSessionTask, didFinishCollecting metrics: URLSessionTaskMetrics) {
+//        print("\(#function): \(metrics)")
+        print("\(#function)")
+        BlueTriangle.captureRequest(metrics: metrics)
+    }
+}

--- a/Sources/BlueTriangle/NetworkCaptureSessionDelegate.swift
+++ b/Sources/BlueTriangle/NetworkCaptureSessionDelegate.swift
@@ -11,6 +11,11 @@ import Foundation
 open class NetworkCaptureSessionDelegate: NSObject, URLSessionTaskDelegate {
 
     /// Tells the delegate that the session finished collecting metrics for the task.
+    ///
+    /// You can override this method to perform additional tasks associated with the collected
+    /// metrics. If you override this method, you must call `super` at some point in your
+    /// implementation.
+    ///
     /// - Parameters:
     ///   - session: The session collecting the metrics.
     ///   - task: The task whose metrics have been collected.

--- a/Sources/BlueTriangle/Protocols/CapturedRequestCollecting.swift
+++ b/Sources/BlueTriangle/Protocols/CapturedRequestCollecting.swift
@@ -10,4 +10,5 @@ import Foundation
 protocol CapturedRequestCollecting: Actor {
     func start(page: Page, startTime: TimeInterval)
     func collect(timer: InternalTimer, response: URLResponse?)
+    func collect(metrics: URLSessionTaskMetrics)
 }

--- a/Tests/BlueTriangleTests/Mocks/CapturedRequestCollectorMock.swift
+++ b/Tests/BlueTriangleTests/Mocks/CapturedRequestCollectorMock.swift
@@ -1,0 +1,37 @@
+//
+//  CapturedRequestCollectorMock.swift
+//
+//  Created by Mathew Gacy on 11/10/22.
+//  Copyright © 2022 Blue Triangle. All rights reserved.
+//
+
+@testable import BlueTriangle
+import Foundation
+
+actor CapturedRequestCollectorMock: CapturedRequestCollecting {
+    var onStart: (Page, TimeInterval) -> Void
+    var onCollectTimer: (InternalTimer, URLResponse?) -> Void
+    var onCollectMetrics: (URLSessionTaskMetrics) -> Void
+
+    init(
+        onStart: @escaping (Page, TimeInterval) -> Void = { _, _ in },
+        onCollectTimer: @escaping (InternalTimer, URLResponse?) -> Void = { _, _ in },
+        onCollectMetrics: @escaping (URLSessionTaskMetrics) -> Void = { _ in }
+    ) {
+        self.onStart = onStart
+        self.onCollectTimer = onCollectTimer
+        self.onCollectMetrics = onCollectMetrics
+    }
+
+    func start(page: Page, startTime: TimeInterval) {
+        onStart(page, startTime)
+    }
+
+    func collect(timer: InternalTimer, response: URLResponse?) {
+        onCollectTimer(timer, response)
+    }
+
+    func collect(metrics: URLSessionTaskMetrics) {
+        onCollectMetrics(metrics)
+    }
+}

--- a/Tests/BlueTriangleTests/Mocks/URLProtocolMock.swift
+++ b/Tests/BlueTriangleTests/Mocks/URLProtocolMock.swift
@@ -10,7 +10,7 @@ import XCTest
 
 final class URLProtocolMock: URLProtocol {
     static var responseQueue: DispatchQueue = .global()
-    static var responseDelay: TimeInterval? = 0.3
+    static var responseDelay: TimeInterval? = 0.1
     static var responseProvider: (URL) throws -> (Data, HTTPURLResponse) = { url in
         (Data(), Mock.makeHTTPResponse(url: url))
     }
@@ -43,6 +43,11 @@ final class URLProtocolMock: URLProtocol {
             client.urlProtocol(self, didFailWithError: error)
         }
         client.urlProtocolDidFinishLoading(self)
+    }
+
+    static func reset() {
+        responseDelay = 0.1
+        responseProvider = { (Data(), Mock.makeHTTPResponse(url: $0)) }
     }
 }
 

--- a/Tests/BlueTriangleTests/NetworkCaptureDelegateTests.swift
+++ b/Tests/BlueTriangleTests/NetworkCaptureDelegateTests.swift
@@ -25,7 +25,6 @@ final class NetworkCaptureDelegateTests: XCTestCase {
         let metricsExpectation = expectation(description: "Collected session task metrics")
         var metrics: URLSessionTaskMetrics!
         let requestCollector = CapturedRequestCollectorMock(onCollectMetrics: { taskMetrics in
-            print("Metrics: \(taskMetrics)")
             metrics = taskMetrics
             metricsExpectation.fulfill()
         })

--- a/Tests/BlueTriangleTests/NetworkCaptureDelegateTests.swift
+++ b/Tests/BlueTriangleTests/NetworkCaptureDelegateTests.swift
@@ -1,0 +1,71 @@
+//
+//  NetworkCaptureDelegateTests.swift
+//
+//  Created by Mathew Gacy on 11/10/22.
+//  Copyright © 2022 Blue Triangle. All rights reserved.
+//
+
+@testable import BlueTriangle
+import XCTest
+
+final class NetworkCaptureDelegateTests: XCTestCase {
+
+    static func makeSession() -> URLSession {
+        URLSession(
+            configuration: .mock,
+            delegate: NetworkCaptureSessionDelegate(),
+            delegateQueue: nil)
+    }
+
+    override func tearDownWithError() throws {
+        URLProtocolMock.reset()
+    }
+
+    func testMetricsAreCaptured() async throws {
+        let metricsExpectation = expectation(description: "Collected session task metrics")
+        var metrics: URLSessionTaskMetrics!
+        let requestCollector = CapturedRequestCollectorMock(onCollectMetrics: { taskMetrics in
+            print("Metrics: \(taskMetrics)")
+            metrics = taskMetrics
+            metricsExpectation.fulfill()
+        })
+
+        let configuration = BlueTriangleConfiguration()
+        Mock.configureBlueTriangle(configuration: configuration)
+
+        // Configure Blue Triangle
+        BlueTriangle.reconfigure(
+            configuration: configuration,
+            logger: LoggerMock(),
+            uploader: UploaderMock(),
+            shouldCaptureRequests: true,
+            requestCollector: requestCollector
+        )
+
+        let resourceURL: URL = "https://example.com"
+        let response = Mock.makeHTTPResponse(
+            url: resourceURL,
+            headerFields: ["Content-Type": "application/json"])
+
+        URLProtocolMock.responseProvider = { _ in
+            (Mock.successJSON, response)
+        }
+
+        // Start timer for network capture
+        _ = BlueTriangle.startTimer(page: Page(pageName: "Example"))
+
+        // Request to capture
+        let session = Self.makeSession()
+
+        let responseExpectation = expectation(description: "Received response")
+        session.dataTask(with: resourceURL) { data, response, error in
+            responseExpectation.fulfill()
+        }.resume()
+
+        await waitForExpectations(timeout: 1)
+
+        XCTAssert(metrics.taskInterval.start.timeIntervalSince1970 > 0)
+        XCTAssert(metrics.taskInterval.end.timeIntervalSince1970 > 0)
+        XCTAssert(metrics.taskInterval.duration > 0)
+    }
+}

--- a/Tests/BlueTriangleTests/NetworkCaptureDelegateTests.swift
+++ b/Tests/BlueTriangleTests/NetworkCaptureDelegateTests.swift
@@ -21,7 +21,7 @@ final class NetworkCaptureDelegateTests: XCTestCase {
         URLProtocolMock.reset()
     }
 
-    func testMetricsAreCaptured() async throws {
+    func testMetricsAreCapturedWithCompletionHandler() throws {
         let metricsExpectation = expectation(description: "Collected session task metrics")
         var metrics: URLSessionTaskMetrics!
         let requestCollector = CapturedRequestCollectorMock(onCollectMetrics: { taskMetrics in
@@ -60,6 +60,52 @@ final class NetworkCaptureDelegateTests: XCTestCase {
         session.dataTask(with: resourceURL) { data, response, error in
             responseExpectation.fulfill()
         }.resume()
+
+        waitForExpectations(timeout: 1, handler: nil)
+
+        XCTAssert(metrics.taskInterval.start.timeIntervalSince1970 > 0)
+        XCTAssert(metrics.taskInterval.end.timeIntervalSince1970 > 0)
+        XCTAssert(metrics.taskInterval.duration > 0)
+    }
+
+    func testMetricsAreCapturedWithAsync() async throws {
+        let metricsExpectation = expectation(description: "Collected session task metrics")
+        var metrics: URLSessionTaskMetrics!
+        let requestCollector = CapturedRequestCollectorMock(onCollectMetrics: { taskMetrics in
+            metrics = taskMetrics
+            metricsExpectation.fulfill()
+        })
+
+        let configuration = BlueTriangleConfiguration()
+        Mock.configureBlueTriangle(configuration: configuration)
+
+        // Configure Blue Triangle
+        BlueTriangle.reconfigure(
+            configuration: configuration,
+            logger: LoggerMock(),
+            uploader: UploaderMock(),
+            shouldCaptureRequests: true,
+            requestCollector: requestCollector
+        )
+
+        let resourceURL: URL = "https://example.com"
+        let response = Mock.makeHTTPResponse(
+            url: resourceURL,
+            headerFields: ["Content-Type": "application/json"])
+
+        URLProtocolMock.responseProvider = { _ in
+            (Mock.successJSON, response)
+        }
+
+        // Start timer for network capture
+        _ = BlueTriangle.startTimer(page: Page(pageName: "Example"))
+
+        // Request to capture
+        let session = Self.makeSession()
+
+        let responseExpectation = expectation(description: "Received response")
+        _ = try await session.data(from: resourceURL)
+        responseExpectation.fulfill()
 
         await waitForExpectations(timeout: 1)
 


### PR DESCRIPTION
This adds `NetworkCaptureSessionDelegate` and `BlueTriangle.captureRequest(metrics:)` to enable an alternative means of capturing network requests using the `URLSessionTaskDelegate.(_:task:didFinishCollecting:)` method.

It also updates the `CapturedRequest` initializer used by the `URLSession` methods to use expected content length for the decoded body size to match the values obtained when using the `URLSessionDelegate` method.