### PR TITLE
Fix CI Test Timeout for NetworkCapture Test

### DIFF
--- a/Sources/BlueTriangle/NetworkCapture/CapturedRequestCollector.swift
+++ b/Sources/BlueTriangle/NetworkCapture/CapturedRequestCollector.swift
@@ -21,7 +21,7 @@ actor CapturedRequestCollector: CapturedRequestCollecting {
         timerManager: CaptureTimerManaging,
         requestBuilder: CapturedRequestBuilder,
         uploader: Uploading,
-        uploadTaskPriority: TaskPriority = .background
+        uploadTaskPriority: TaskPriority
     ) {
         self.logger = logger
         self.timerManager = timerManager
@@ -91,6 +91,7 @@ actor CapturedRequestCollector: CapturedRequestCollecting {
 // MARK: - Supporting Types
 extension CapturedRequestCollector {
     struct Configuration {
+        let uploadTaskPriority: TaskPriority
         let timerManagingProvider: (NetworkCaptureConfiguration) -> CaptureTimerManaging
 
         func makeRequestCollector(
@@ -101,13 +102,14 @@ extension CapturedRequestCollector {
         ) -> CapturedRequestCollector {
             let timerManager = timerManagingProvider(networkCaptureConfiguration)
             return CapturedRequestCollector(logger: logger,
-                                                 timerManager: timerManager,
-                                                 requestBuilder: requestBuilder,
-                                                 uploader: uploader)
+                                            timerManager: timerManager,
+                                            requestBuilder: requestBuilder,
+                                            uploader: uploader,
+                                            uploadTaskPriority: uploadTaskPriority)
         }
 
         static var live: Self {
-            return Configuration { configuration in
+            Configuration(uploadTaskPriority: .background) { configuration in
                 CaptureTimerManager(configuration: configuration)
             }
         }

--- a/Tests/BlueTriangleTests/Mocks/Mock.swift
+++ b/Tests/BlueTriangleTests/Mocks/Mock.swift
@@ -134,7 +134,7 @@ extension Mock {
     static func makeRequestCollectorConfiguration(
         timerManagingProvider: @escaping (NetworkCaptureConfiguration) -> CaptureTimerManaging = { _ in CaptureTimerManagerMock() }
     ) -> CapturedRequestCollector.Configuration {
-        .init(timerManagingProvider: timerManagingProvider)
+        .init(uploadTaskPriority: .high, timerManagingProvider: timerManagingProvider)
     }
 }
 


### PR DESCRIPTION
Add the `uploadTaskPriority` to `CapturedRequestCollector.Configuration` and use an elevated priority in `BlueTriangleTests.testNetworkCapture()`. This should fix the remaining issue with sporadic test failures on the GitHub runner.