### PR TITLE
Update ImageLoading for View Timers

### DIFF
--- a/Examples/Example-SwiftUI/Example-SwiftUI.xcodeproj/project.pbxproj
+++ b/Examples/Example-SwiftUI/Example-SwiftUI.xcodeproj/project.pbxproj
@@ -28,6 +28,7 @@
 		C94BF02D290B1825007E1C25 /* CheckoutViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C94BF02C290B1825007E1C25 /* CheckoutViewModel.swift */; };
 		C9B637D1290B26A6006E5F90 /* View+ErrorAlert.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9B637D0290B26A6006E5F90 /* View+ErrorAlert.swift */; };
 		C9C7D88F2939029C00950C55 /* LineItemRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9C7D88E2939029C00950C55 /* LineItemRow.swift */; };
+		C9C7D891293930E900950C55 /* ImageLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9C7D890293930E900950C55 /* ImageLoader.swift */; };
 		C9E1141A291421F00031E874 /* IdentifiedCollections in Frameworks */ = {isa = PBXBuildFile; productRef = C9E11419291421F00031E874 /* IdentifiedCollections */; };
 		C9E1141C291425340031E874 /* CartRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9E1141B291425340031E874 /* CartRepository.swift */; };
 		C9E1141E291454DB0031E874 /* Service+BTT.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9E1141D291454DB0031E874 /* Service+BTT.swift */; };
@@ -79,6 +80,7 @@
 		C94BF02C290B1825007E1C25 /* CheckoutViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CheckoutViewModel.swift; sourceTree = "<group>"; };
 		C9B637D0290B26A6006E5F90 /* View+ErrorAlert.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View+ErrorAlert.swift"; sourceTree = "<group>"; };
 		C9C7D88E2939029C00950C55 /* LineItemRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LineItemRow.swift; sourceTree = "<group>"; };
+		C9C7D890293930E900950C55 /* ImageLoader.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = ImageLoader.swift; path = "Example-SwiftUI/ImageLoader.swift"; sourceTree = SOURCE_ROOT; };
 		C9E1141B291425340031E874 /* CartRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CartRepository.swift; sourceTree = "<group>"; };
 		C9F4A4122900DB6100BCDF3E /* Example-SwiftUI.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Example-SwiftUI.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		C9F4A4152900DB6100BCDF3E /* ExampleApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExampleApp.swift; sourceTree = "<group>"; };
@@ -214,6 +216,7 @@
 				C9F4A4442900DDE900BCDF3E /* Constants.swift */,
 				C9F4A4152900DB6100BCDF3E /* ExampleApp.swift */,
 				C9E1141B291425340031E874 /* CartRepository.swift */,
+				C9C7D890293930E900950C55 /* ImageLoader.swift */,
 				C94BF027290B100C007E1C25 /* Extensions */,
 				C91C599B2927E1C900A20136 /* Models */,
 				C9F4A41B2900DB6200BCDF3E /* Preview Content */,
@@ -426,6 +429,7 @@
 				C94BF01D290AE58A007E1C25 /* SettingsView.swift in Sources */,
 				C9B637D1290B26A6006E5F90 /* View+ErrorAlert.swift in Sources */,
 				C94BF011290ADC20007E1C25 /* ProductCell.swift in Sources */,
+				C9C7D891293930E900950C55 /* ImageLoader.swift in Sources */,
 				C91C599F2927E1FD00A20136 /* CartItemModel.swift in Sources */,
 				C94BF024290AE9C0007E1C25 /* ProductDetailViewModel.swift in Sources */,
 				C9F4A4162900DB6100BCDF3E /* ExampleApp.swift in Sources */,

--- a/Examples/Example-SwiftUI/Example-SwiftUI.xcodeproj/project.pbxproj
+++ b/Examples/Example-SwiftUI/Example-SwiftUI.xcodeproj/project.pbxproj
@@ -29,9 +29,9 @@
 		C9B637D1290B26A6006E5F90 /* View+ErrorAlert.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9B637D0290B26A6006E5F90 /* View+ErrorAlert.swift */; };
 		C9C7D88F2939029C00950C55 /* LineItemRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9C7D88E2939029C00950C55 /* LineItemRow.swift */; };
 		C9C7D891293930E900950C55 /* ImageLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9C7D890293930E900950C55 /* ImageLoader.swift */; };
+		C9C7D8932939315D00950C55 /* RemoteImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9C7D8922939315D00950C55 /* RemoteImage.swift */; };
 		C9E1141A291421F00031E874 /* IdentifiedCollections in Frameworks */ = {isa = PBXBuildFile; productRef = C9E11419291421F00031E874 /* IdentifiedCollections */; };
 		C9E1141C291425340031E874 /* CartRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9E1141B291425340031E874 /* CartRepository.swift */; };
-		C9E1141E291454DB0031E874 /* Service+BTT.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9E1141D291454DB0031E874 /* Service+BTT.swift */; };
 		C9F4A4162900DB6100BCDF3E /* ExampleApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9F4A4152900DB6100BCDF3E /* ExampleApp.swift */; };
 		C9F4A41A2900DB6200BCDF3E /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = C9F4A4192900DB6200BCDF3E /* Assets.xcassets */; };
 		C9F4A41D2900DB6200BCDF3E /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = C9F4A41C2900DB6200BCDF3E /* Preview Assets.xcassets */; };
@@ -81,6 +81,7 @@
 		C9B637D0290B26A6006E5F90 /* View+ErrorAlert.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View+ErrorAlert.swift"; sourceTree = "<group>"; };
 		C9C7D88E2939029C00950C55 /* LineItemRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LineItemRow.swift; sourceTree = "<group>"; };
 		C9C7D890293930E900950C55 /* ImageLoader.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = ImageLoader.swift; path = "Example-SwiftUI/ImageLoader.swift"; sourceTree = SOURCE_ROOT; };
+		C9C7D8922939315D00950C55 /* RemoteImage.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RemoteImage.swift; sourceTree = "<group>"; };
 		C9E1141B291425340031E874 /* CartRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CartRepository.swift; sourceTree = "<group>"; };
 		C9F4A4122900DB6100BCDF3E /* Example-SwiftUI.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Example-SwiftUI.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		C9F4A4152900DB6100BCDF3E /* ExampleApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExampleApp.swift; sourceTree = "<group>"; };
@@ -162,6 +163,7 @@
 				C93FCCB829103A7E00633487 /* CartItemRow.swift */,
 				C9C7D88E2939029C00950C55 /* LineItemRow.swift */,
 				C94BF010290ADC20007E1C25 /* ProductCell.swift */,
+				C9C7D8922939315D00950C55 /* RemoteImage.swift */,
 			);
 			path = Components;
 			sourceTree = "<group>";
@@ -433,6 +435,7 @@
 				C91C599F2927E1FD00A20136 /* CartItemModel.swift in Sources */,
 				C94BF024290AE9C0007E1C25 /* ProductDetailViewModel.swift in Sources */,
 				C9F4A4162900DB6100BCDF3E /* ExampleApp.swift in Sources */,
+				C9C7D8932939315D00950C55 /* RemoteImage.swift in Sources */,
 				C94BF02B290B1803007E1C25 /* CheckoutView.swift in Sources */,
 				C94BF019290AE519007E1C25 /* TabContainerView.swift in Sources */,
 				C9F4A4452900DDE900BCDF3E /* Constants.swift in Sources */,

--- a/Examples/Example-SwiftUI/Example-SwiftUI.xcodeproj/project.pbxproj
+++ b/Examples/Example-SwiftUI/Example-SwiftUI.xcodeproj/project.pbxproj
@@ -30,6 +30,7 @@
 		C9C7D88F2939029C00950C55 /* LineItemRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9C7D88E2939029C00950C55 /* LineItemRow.swift */; };
 		C9C7D891293930E900950C55 /* ImageLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9C7D890293930E900950C55 /* ImageLoader.swift */; };
 		C9C7D8932939315D00950C55 /* RemoteImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9C7D8922939315D00950C55 /* RemoteImage.swift */; };
+		C9C7D895293E417300950C55 /* UIColor+Utils.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9C7D894293E417300950C55 /* UIColor+Utils.swift */; };
 		C9E1141A291421F00031E874 /* IdentifiedCollections in Frameworks */ = {isa = PBXBuildFile; productRef = C9E11419291421F00031E874 /* IdentifiedCollections */; };
 		C9E1141C291425340031E874 /* CartRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9E1141B291425340031E874 /* CartRepository.swift */; };
 		C9F4A4162900DB6100BCDF3E /* ExampleApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9F4A4152900DB6100BCDF3E /* ExampleApp.swift */; };
@@ -82,6 +83,7 @@
 		C9C7D88E2939029C00950C55 /* LineItemRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LineItemRow.swift; sourceTree = "<group>"; };
 		C9C7D890293930E900950C55 /* ImageLoader.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = ImageLoader.swift; path = "Example-SwiftUI/ImageLoader.swift"; sourceTree = SOURCE_ROOT; };
 		C9C7D8922939315D00950C55 /* RemoteImage.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RemoteImage.swift; sourceTree = "<group>"; };
+		C9C7D894293E417300950C55 /* UIColor+Utils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIColor+Utils.swift"; sourceTree = "<group>"; };
 		C9E1141B291425340031E874 /* CartRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CartRepository.swift; sourceTree = "<group>"; };
 		C9F4A4122900DB6100BCDF3E /* Example-SwiftUI.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Example-SwiftUI.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		C9F4A4152900DB6100BCDF3E /* ExampleApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExampleApp.swift; sourceTree = "<group>"; };
@@ -185,6 +187,7 @@
 			children = (
 				C94BF028290B1018007E1C25 /* Collection+Utils.swift */,
 				C91C59A02928017B00A20136 /* String+LocalizedError.swift */,
+				C9C7D894293E417300950C55 /* UIColor+Utils.swift */,
 				C9B637D0290B26A6006E5F90 /* View+ErrorAlert.swift */,
 			);
 			path = Extensions;
@@ -428,6 +431,7 @@
 				C94BF029290B1018007E1C25 /* Collection+Utils.swift in Sources */,
 				C91C599D2927E1E000A20136 /* CartModel.swift in Sources */,
 				C94BF00E290ADC02007E1C25 /* ProductDetailView.swift in Sources */,
+				C9C7D895293E417300950C55 /* UIColor+Utils.swift in Sources */,
 				C94BF01D290AE58A007E1C25 /* SettingsView.swift in Sources */,
 				C9B637D1290B26A6006E5F90 /* View+ErrorAlert.swift in Sources */,
 				C94BF011290ADC20007E1C25 /* ProductCell.swift in Sources */,

--- a/Examples/Example-SwiftUI/Example-SwiftUI/ExampleApp.swift
+++ b/Examples/Example-SwiftUI/Example-SwiftUI/ExampleApp.swift
@@ -21,7 +21,9 @@ struct Example_SwiftUIApp: App {
 
     var body: some Scene {
         WindowGroup {
-            TabContainerView(service: .live)
+            TabContainerView(
+                imageLoader: .live,
+                service: .live)
         }
     }
 }

--- a/Examples/Example-SwiftUI/Example-SwiftUI/Extensions/UIColor+Utils.swift
+++ b/Examples/Example-SwiftUI/Example-SwiftUI/Extensions/UIColor+Utils.swift
@@ -1,0 +1,25 @@
+//
+//  UIColor+Utils.swift
+//
+//  Created by Mathew Gacy on 12/5/22.
+//  Copyright © 2022 Blue Triangle. All rights reserved.
+//
+
+import UIKit
+
+extension UIColor {
+    static func random() -> UIColor {
+        UIColor(
+            red: CGFloat(drand48()),
+            green: CGFloat(drand48()),
+            blue: CGFloat(drand48()),
+            alpha: 1.0)
+    }
+
+    func image(_ size: CGSize = CGSize(width: 300, height: 300)) -> UIImage {
+        UIGraphicsImageRenderer(size: size).image { rendererContext in
+            self.setFill()
+            rendererContext.fill(CGRect(origin: .zero, size: size))
+        }
+    }
+}

--- a/Examples/Example-SwiftUI/Example-SwiftUI/ImageLoader.swift
+++ b/Examples/Example-SwiftUI/Example-SwiftUI/ImageLoader.swift
@@ -13,10 +13,18 @@ import UIKit
 
 // MARK: - Models
 
-enum ImageStatus {
+enum ImageStatus: CustomStringConvertible {
     case loading
     case downloaded(UIImage)
     case error(Error)
+
+    var description: String {
+        switch self {
+        case .loading: return "loading"
+        case .downloaded: return "downloaded"
+        case .error(let error): return error.localizedDescription
+        }
+    }
 }
 
 struct ImageDownload: Identifiable {

--- a/Examples/Example-SwiftUI/Example-SwiftUI/ImageLoader.swift
+++ b/Examples/Example-SwiftUI/Example-SwiftUI/ImageLoader.swift
@@ -1,0 +1,111 @@
+//
+//  ImageLoader.swift
+//
+//  Created by Mathew Gacy on 11/27/22.
+//  Copyright © 2022 Blue Triangle. All rights reserved.
+//
+
+import Foundation
+import IdentifiedCollections
+import Service
+import SwiftUI
+import UIKit
+
+// MARK: - Models
+
+enum ImageStatus {
+    case loading
+    case downloaded(UIImage)
+    case error(Error)
+}
+
+struct ImageDownload: Identifiable {
+    let id: URL
+    let status: ImageStatus
+}
+
+// MARK: - EnvironmentValues
+
+struct ImageLoaderKey: EnvironmentKey {
+    static let defaultValue = ImageLoader.shared
+}
+
+extension EnvironmentValues {
+    var imageLoader: ImageLoader {
+        get { self[ImageLoaderKey.self] }
+        set { self[ImageLoaderKey.self ] = newValue}
+    }
+}
+
+// MARK: - ImageLoader
+
+final class ImageLoader: ObservableObject {
+    struct ImageResult: Identifiable {
+        let id: URL
+        let result: Result<UIImage, Error>
+    }
+
+    public static let shared: ImageLoader = {
+        ImageLoader()
+    }()
+
+    private var networking: (URL) async throws -> ResponseValue = { url in
+        try ResponseValue(try await URLSession.shared.data(from: url))
+    }
+
+    @Published @MainActor private(set) var images: IdentifiedArrayOf<ImageDownload> = []
+
+    func fetch(urls: [URL]) async {
+        await withTaskGroup(of: ImageResult.self, returning: Void.self) { group in
+            urls.forEach { url in
+                group.addTask {
+                    await self.fetchImage(url: url)
+                }
+            }
+
+            await updateImages(
+                IdentifiedArrayOf(
+                    uniqueElements: urls.map { ImageDownload(id: $0, status: .loading) }))
+
+            for await imageResult in group {
+                switch imageResult.result {
+                case .success(let image):
+                    await updateStatus(imageResult.id, status: .downloaded(image))
+                case .failure(let error):
+                    await updateStatus(imageResult.id, status: .error(error))
+                }
+            }
+        }
+    }
+}
+
+private extension ImageLoader {
+    func fetchImage(url: URL) async -> ImageResult {
+        do {
+            let responseValue = try await networking(url)
+                .validate()
+
+            guard let image = UIImage(data: responseValue.data) else {
+                throw "Cannot parse image"
+            }
+
+            return ImageResult(id: url, result: .success(image))
+        } catch {
+            return ImageResult(id: url, result: .failure(error))
+        }
+    }
+
+    @MainActor
+    func updateImages(_ newImages: IdentifiedArrayOf<ImageDownload>) {
+        withAnimation {
+            images = newImages
+        }
+    }
+
+    @MainActor
+    func updateStatus(_ url: URL, status: ImageStatus) {
+        withAnimation {
+            images[id: url] = ImageDownload(id: url, status: status)
+        }
+    }
+}

--- a/Examples/Example-SwiftUI/Example-SwiftUI/ViewModels/ProductDetailViewModel.swift
+++ b/Examples/Example-SwiftUI/Example-SwiftUI/ViewModels/ProductDetailViewModel.swift
@@ -9,10 +9,11 @@ import Foundation
 import Service
 
 final class ProductDetailViewModel: ObservableObject {
-    private let cartRepository: CartRepository
-    private let product: Product
-    @Published var quantity: Int
     @Published var error: Error?
+    @Published var quantity: Int
+    private let cartRepository: CartRepository
+    private let imageLoader: ImageLoader
+    private let product: Product
 
     var name: String {
         product.name
@@ -26,14 +27,27 @@ final class ProductDetailViewModel: ObservableObject {
         "$\(product.price)"
     }
 
-    var imageURL: URL {
-        product.image
-    }
-
-    init(cartRepository: CartRepository, product: Product, quantity: Int = 1) {
+    init(
+        cartRepository: CartRepository,
+        imageLoader: ImageLoader,
+        product: Product, quantity: Int = 1
+    ) {
         self.cartRepository = cartRepository
+        self.imageLoader = imageLoader
         self.product = product
         self.quantity = quantity
+    }
+
+    @MainActor
+    func imageStatus() async -> ImageStatus? {
+        // Start timer ...
+
+        let status = await imageLoader.images[product.image]
+
+        // End timer
+        print("End \(String(describing: self)) Timer")
+
+        return status
     }
 
     @MainActor

--- a/Examples/Example-SwiftUI/Example-SwiftUI/ViewModels/ProductDetailViewModel.swift
+++ b/Examples/Example-SwiftUI/Example-SwiftUI/ViewModels/ProductDetailViewModel.swift
@@ -37,9 +37,13 @@ final class ProductDetailViewModel: ObservableObject {
     }
 
     @MainActor
-    func addToCart() {
-        cartRepository.add(
-            product: product,
-            quantity: quantity)
+    func addToCart() async {
+        do {
+            try  await cartRepository.add(
+                product: product,
+                quantity: quantity)
+        } catch {
+            self.error = error
+        }
     }
 }

--- a/Examples/Example-SwiftUI/Example-SwiftUI/ViewModels/ProductListViewModel.swift
+++ b/Examples/Example-SwiftUI/Example-SwiftUI/ViewModels/ProductListViewModel.swift
@@ -12,29 +12,61 @@ final class ProductListViewModel: ObservableObject {
     @Published private(set) var products: ([Product], [Product]) = ([], [])
     @Published var error: Error?
     private let cartRepository: CartRepository
+    private let imageLoader: ImageLoader
     private let service: Service
+    private var hasAppeared: Bool = false
 
-    init(cartRepository: CartRepository, service: Service) {
+    init(
+        cartRepository: CartRepository,
+        imageLoader: ImageLoader,
+        service: Service
+    ) {
         self.cartRepository = cartRepository
+        self.imageLoader = imageLoader
         self.service = service
     }
 
     @MainActor
     func loadProducts() async {
         do {
-            products = try await service.products().splitTuple()
+            // Start timer ...
+
+            let productResponse = try await service.products()
+            products = productResponse.splitTuple()
+
+            let imageURLS = productResponse.map { $0.image }
+            try await imageLoader.fetch(urls: imageURLS)
         } catch {
             self.error = error
         }
+
+        // End timer after view images have loaded
+        print("End \(String(describing: self)) Timer")
+    }
+
+    func onAppear() async {
+        guard !hasAppeared else {
+            return
+        }
+
+        defer {
+            hasAppeared = true
+        }
+        await loadProducts()
+    }
+
+    func imageStatus(_ url: URL) async -> ImageStatus? {
+        await imageLoader.images[url]
     }
 
     func detailViewModel(for productID: Product.ID) -> ProductDetailViewModel? {
-        guard let product = products.0.first(where: { $0.id == productID }) ?? products.1.first(where: { $0.id == productID }) else  {
+        guard let product = products.0.first(where: { $0.id == productID }) ?? products.1.first(where: { $0.id == productID }) else {
             return nil
         }
 
         return ProductDetailViewModel(
             cartRepository: cartRepository,
+            imageLoader: imageLoader,
             product: product)
     }
 }

--- a/Examples/Example-SwiftUI/Example-SwiftUI/ViewModels/ProductListViewModel.swift
+++ b/Examples/Example-SwiftUI/Example-SwiftUI/ViewModels/ProductListViewModel.swift
@@ -8,7 +8,6 @@
 import Foundation
 import Service
 
-@MainActor
 final class ProductListViewModel: ObservableObject {
     @Published private(set) var products: ([Product], [Product]) = ([], [])
     @Published var error: Error?
@@ -20,6 +19,7 @@ final class ProductListViewModel: ObservableObject {
         self.service = service
     }
 
+    @MainActor
     func loadProducts() async {
         do {
             products = try await service.products().splitTuple()

--- a/Examples/Example-SwiftUI/Example-SwiftUI/Views/CartView.swift
+++ b/Examples/Example-SwiftUI/Example-SwiftUI/Views/CartView.swift
@@ -10,9 +10,11 @@ import SwiftUI
 import Service
 
 struct CartView: View {
+    private let imageLoader: ImageLoader
     @ObservedObject var viewModel: CartViewModel
 
-    init(viewModel: CartViewModel) {
+    init(imageLoader: ImageLoader, viewModel: CartViewModel) {
+        self.imageLoader = imageLoader
         self.viewModel = viewModel
     }
 
@@ -56,7 +58,6 @@ struct CartView: View {
 }
 
 private extension CartView {
-    @ViewBuilder
     func footer(estimatedTax: Double, subtotal: Double) -> some View {
         VStack(spacing: 8) {
             LineItemRow(
@@ -71,11 +72,11 @@ private extension CartView {
         }
     }
 
-    @ViewBuilder
     func cartList(_ viewModel: CartViewModel) -> some View {
         List {
             ForEach(viewModel.productItems) { productItem in
                 CartItemRow(
+                    imageStatusProvider: { await imageLoader.images[$0] },
                     item: productItem,
                     onIncrement: {
                         Task {
@@ -101,6 +102,7 @@ private extension CartView {
 struct CartView_Previews: PreviewProvider {
     static var previews: some View {
         CartView(
+            imageLoader: .mock,
             viewModel: .init(
                 service: .mock,
                 cartRepository: .mock

--- a/Examples/Example-SwiftUI/Example-SwiftUI/Views/CartView.swift
+++ b/Examples/Example-SwiftUI/Example-SwiftUI/Views/CartView.swift
@@ -78,10 +78,14 @@ private extension CartView {
                 CartItemRow(
                     item: productItem,
                     onIncrement: {
-                        viewModel.increment(id: productItem.id)
+                        Task {
+                            await viewModel.increment(id: productItem.id)
+                        }
                     },
                     onDecrement: {
-                        viewModel.decrement(id: productItem.id)
+                        Task {
+                            await viewModel.decrement(id: productItem.id)
+                        }
                     })
             }
 

--- a/Examples/Example-SwiftUI/Example-SwiftUI/Views/CheckoutView.swift
+++ b/Examples/Example-SwiftUI/Example-SwiftUI/Views/CheckoutView.swift
@@ -9,7 +9,7 @@ import Service
 import SwiftUI
 
 struct CheckoutView: View {
-    @ObservedObject var  viewModel: CheckoutViewModel
+    @ObservedObject var viewModel: CheckoutViewModel
 
     init(viewModel: CheckoutViewModel) {
         self.viewModel = viewModel

--- a/Examples/Example-SwiftUI/Example-SwiftUI/Views/Components/RemoteImage.swift
+++ b/Examples/Example-SwiftUI/Example-SwiftUI/Views/Components/RemoteImage.swift
@@ -1,0 +1,32 @@
+//
+//  RemoteImage.swift
+//
+//  Created by Mathew Gacy on 11/28/22.
+//  Copyright © 2022 Blue Triangle. All rights reserved.
+//
+
+import SwiftUI
+
+struct RemoteImage: View {
+    let contentMode: ContentMode = .fit
+    let imageStatus: ImageStatus?
+
+    var body: some View {
+        switch imageStatus {
+        case .downloaded(let uiImage):
+            Image(uiImage: uiImage)
+                .resizable()
+                .aspectRatio(contentMode: contentMode)
+                .cornerRadius(8)
+        case .error:
+            Image(systemName: "exclamationmark.circle")
+                .resizable()
+                .aspectRatio(contentMode: contentMode)
+                .foregroundColor(.red)
+                .padding()
+        default:
+            ProgressView()
+                .padding()
+        }
+    }
+}

--- a/Examples/Example-SwiftUI/Example-SwiftUI/Views/Components/RemoteImage.swift
+++ b/Examples/Example-SwiftUI/Example-SwiftUI/Views/Components/RemoteImage.swift
@@ -8,25 +8,41 @@
 import SwiftUI
 
 struct RemoteImage: View {
+    @State var imageResult: Result<UIImage, Error>?
     let contentMode: ContentMode = .fit
-    let imageStatus: ImageStatus?
+    let imageStatus: ImageStatus
 
     var body: some View {
-        switch imageStatus {
-        case .downloaded(let uiImage):
-            Image(uiImage: uiImage)
-                .resizable()
-                .aspectRatio(contentMode: contentMode)
-                .cornerRadius(8)
-        case .error:
-            Image(systemName: "exclamationmark.circle")
-                .resizable()
-                .aspectRatio(contentMode: contentMode)
-                .foregroundColor(.red)
-                .padding()
-        default:
-            ProgressView()
-                .padding()
+        Group {
+            if let result = imageResult {
+                switch result {
+                case .success(let uiImage):
+                    Image(uiImage: uiImage)
+                        .resizable()
+                        .aspectRatio(contentMode: contentMode)
+                case .failure:
+                    Image(systemName: "exclamationmark.circle")
+                        .resizable()
+                        .aspectRatio(contentMode: contentMode)
+                        .foregroundColor(.red)
+                        .padding()
+                }
+            } else {
+                ProgressView()
+                    .padding()
+            }
+        }
+        .task {
+            await load(imageStatus)
+        }}
+
+    func load(_ status: ImageStatus) async {
+        switch status {
+        case .loading(let task):
+            imageResult = await task.value.result
+
+        case .downloaded(let result):
+            imageResult = result
         }
     }
 }

--- a/Examples/Example-SwiftUI/Example-SwiftUI/Views/ProductDetailView.swift
+++ b/Examples/Example-SwiftUI/Example-SwiftUI/Views/ProductDetailView.swift
@@ -9,7 +9,7 @@ import Service
 import SwiftUI
 
 struct ProductDetailView: View {
-    @StateObject var viewModel: ProductDetailViewModel
+    @ObservedObject var viewModel: ProductDetailViewModel
 
     var body: some View {
         ScrollView {

--- a/Examples/Example-SwiftUI/Example-SwiftUI/Views/ProductDetailView.swift
+++ b/Examples/Example-SwiftUI/Example-SwiftUI/Views/ProductDetailView.swift
@@ -10,24 +10,13 @@ import SwiftUI
 
 struct ProductDetailView: View {
     @ObservedObject var viewModel: ProductDetailViewModel
+    @State var imageStatus: ImageStatus?
 
     var body: some View {
         ScrollView {
             VStack {
-                AsyncImage(url: viewModel.imageURL) { phase in
-                    switch phase {
-                    case .empty:
-                        ProgressView()
-                            .padding()
-                    case .success(let image):
-                        image.resizable()
-                            .aspectRatio(contentMode: .fit)
-                    case .failure:
-                        Image(systemName: "photo")
-                            .padding()
-                    @unknown default:
-                        EmptyView()
-                    }
+                if let imageStatus = imageStatus {
+                    RemoteImage(imageStatus: imageStatus)
                 }
 
                 VStack(alignment: .leading, spacing: 16) {
@@ -54,6 +43,11 @@ struct ProductDetailView: View {
                 })
             .buttonStyle(.primary())
             .padding()
+        }
+        .task {
+            if let status = await viewModel.imageStatus() {
+                imageStatus = status
+            }
         }
         .navigationBarTitleDisplayMode(.inline)
     }
@@ -91,6 +85,7 @@ struct ProductDetailView_Previews: PreviewProvider {
         ProductDetailView(
             viewModel: .init(
                 cartRepository: .mock,
+                imageLoader: .mock,
                 product: Mock.product))
     }
 }

--- a/Examples/Example-SwiftUI/Example-SwiftUI/Views/ProductDetailView.swift
+++ b/Examples/Example-SwiftUI/Example-SwiftUI/Views/ProductDetailView.swift
@@ -45,7 +45,9 @@ struct ProductDetailView: View {
         .overlay(alignment: .bottom) {
             Button(
                 action: {
-                    viewModel.addToCart()
+                    Task {
+                        await viewModel.addToCart()
+                    }
                 },
                 label: {
                     Text("Add to Cart")

--- a/Examples/Example-SwiftUI/Example-SwiftUI/Views/ProductListView.swift
+++ b/Examples/Example-SwiftUI/Example-SwiftUI/Views/ProductListView.swift
@@ -30,7 +30,9 @@ struct ProductListView: View {
                     LazyVGrid(columns: columns) {
                         ForEach(viewModel.products.0) { product in
                             NavigationLink(value: product) {
-                                ProductCell(product: product)
+                                ProductCell(
+                                    imageStatusProvider: viewModel.imageStatus(_:),
+                                    product: product)
                             }
                         }
                     }
@@ -38,7 +40,9 @@ struct ProductListView: View {
                     LazyVGrid(columns: columns) {
                         ForEach(viewModel.products.1) { product in
                             NavigationLink(value: product) {
-                                ProductCell(product: product)
+                                ProductCell(
+                                    imageStatusProvider: viewModel.imageStatus(_:),
+                                    product: product)
                             }
                         }
                     }
@@ -53,8 +57,11 @@ struct ProductListView: View {
                     }
                 }
             }
-            .task {
+            .refreshable {
                 await viewModel.loadProducts()
+            }
+            .task {
+                await viewModel.onAppear()
             }
             .navigationTitle("Products")
         }
@@ -64,8 +71,10 @@ struct ProductListView: View {
 
 struct ProductListView_Previews: PreviewProvider {
     static var previews: some View {
-        ProductListView(viewModel: .init(
-            cartRepository: .mock,
-            service: .mock))
+        ProductListView(
+            viewModel: .init(
+                cartRepository: .mock,
+                imageLoader: .mock,
+                service: .mock))
     }
 }

--- a/Examples/Example-SwiftUI/Example-SwiftUI/Views/SettingsView.swift
+++ b/Examples/Example-SwiftUI/Example-SwiftUI/Views/SettingsView.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 struct SettingsView: View {
-    @StateObject var viewModel: SettingsViewModel
+    @ObservedObject var viewModel: SettingsViewModel
 
     var body: some View {
         Text("Settings")

--- a/Examples/Example-SwiftUI/Example-SwiftUI/Views/TabContainerView.swift
+++ b/Examples/Example-SwiftUI/Example-SwiftUI/Views/TabContainerView.swift
@@ -15,11 +15,13 @@ struct TabContainerView: View {
         case settings
     }
 
-    private let service: Service
-    private let cartRepository: CartRepository
     @State private var selectedTab: Tab = .products
+    private let cartRepository: CartRepository
+    private let imageLoader: ImageLoader
+    private let service: Service
 
-    init(service: Service) {
+    init(imageLoader: ImageLoader, service: Service) {
+        self.imageLoader = imageLoader
         self.service = service
         self.cartRepository = CartRepository(service: service)
     }
@@ -29,6 +31,7 @@ struct TabContainerView: View {
             ProductListView(
                 viewModel: .init(
                     cartRepository: cartRepository,
+                    imageLoader: imageLoader,
                     service: service))
                 .tabItem {
                     Text("Products")
@@ -37,6 +40,7 @@ struct TabContainerView: View {
                 .tag(Tab.products)
 
             CartView(
+                imageLoader: imageLoader,
                 viewModel: .init(
                     service: service,
                     cartRepository: cartRepository))
@@ -58,6 +62,8 @@ struct TabContainerView: View {
 
 struct TabContainerView_Previews: PreviewProvider {
     static var previews: some View {
-        TabContainerView(service: .mock)
+        TabContainerView(
+            imageLoader: .mock,
+            service: .mock)
     }
 }


### PR DESCRIPTION
Adds `ImageLoader` and `RemoteImage` to support better view timing. `ImageLoader` adds image request tasks to a task group so that the `ProductList` timer can be ended once all images have loaded.

I also updated the `CartRepository` methods to be async and added `refreshable` to `ProductListView`

The next and final PR will focus solely on using view timers.