### PR TITLE
Add podspec

### DIFF
--- a/BlueTriangleSDK-Swift.podspec
+++ b/BlueTriangleSDK-Swift.podspec
@@ -8,7 +8,7 @@ Pod::Spec.new do |s|
 
     s.homepage         = 'https://www.bluetriangle.com'
     s.license          = { :type => 'MIT', :file => 'LICENSE.md' }
-    s.author           = { 'Eric Darling' => 'sdk-support@bluetriangle.com' }
+    s.author           = { 'Blue Triangle SDK Support' => 'sdk-support@bluetriangle.com' }
     s.source           = { :git => 'https://github.com/blue-triangle-tech/btt-swift-sdk.git', :tag => s.version.to_s }
     s.social_media_url = 'https://twitter.com/_BlueTriangle'
 

--- a/BlueTriangleSDK-Swift.podspec
+++ b/BlueTriangleSDK-Swift.podspec
@@ -8,7 +8,7 @@ Pod::Spec.new do |s|
 
     s.homepage         = 'https://www.bluetriangle.com'
     s.license          = { :type => 'MIT', :file => 'LICENSE.md' }
-    s.author           = { 'Eric Darling' => 'eric.darling@bluetriangletech.com' }
+    s.author           = { 'Eric Darling' => 'sdk-support@bluetriangle.com' }
     s.source           = { :git => 'https://github.com/blue-triangle-tech/btt-swift-sdk.git', :tag => s.version.to_s }
     s.social_media_url = 'https://twitter.com/_BlueTriangle'
 

--- a/BlueTriangleSDK-Swift.podspec
+++ b/BlueTriangleSDK-Swift.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
     s.name             = 'BlueTriangleSDK-Swift'
-    s.version          = '3.2.2'
+    s.version          = '3.3.0'
     s.summary          = 'BlueTriangleSDK exposes methods to send analytics and crash data to the Blue Triangle portal'
     s.description      = <<-DESC
     BlueTriangleSDK exposes methods to send analytics and crash data to the Blue Triangle portal via HTTP Post

--- a/BlueTriangleSDK-Swift.podspec
+++ b/BlueTriangleSDK-Swift.podspec
@@ -1,0 +1,24 @@
+Pod::Spec.new do |s|
+    s.name             = 'BlueTriangleSDK-Swift'
+    s.version          = '3.2.2'
+    s.summary          = 'BlueTriangleSDK exposes methods to send analytics and crash data to the Blue Triangle portal'
+    s.description      = <<-DESC
+    BlueTriangleSDK exposes methods to send analytics and crash data to the Blue Triangle portal via HTTP Post
+                         DESC
+
+    s.homepage         = 'https://www.bluetriangle.com'
+    s.license          = { :type => 'MIT', :file => 'LICENSE.md' }
+    s.author           = { 'Eric Darling' => 'eric.darling@bluetriangletech.com' }
+    s.source           = { :git => 'https://github.com/blue-triangle-tech/btt-swift-sdk.git', :tag => s.version.to_s }
+    s.social_media_url = 'https://twitter.com/_BlueTriangle'
+
+    s.swift_version = '5.5'
+
+    s.ios.deployment_target = '13.0'
+    s.osx.deployment_target = '10.15'
+    s.tvos.deployment_target = '13.0'
+    s.watchos.deployment_target = '6.0'
+
+    s.source_files = 'Sources/BlueTriangle/**/*.swift'
+
+  end


### PR DESCRIPTION
Adds a `.podspec` file. Note that the version specifies the _next_ release. My expectation is that after we create the next release and deploy it to Cocoapods (which would establish Eric as the owner), we can incorporate Cocoapods deployment in the release workflow with an action to update the `.podspec` with the [Deploy to Cocoapod Action](https://github.com/marketplace/actions/deploy-to-cocoapod-action). 