### PR TITLE
Fix CocoaPods Module Name and Update Release Action

### DIFF
--- a/.github/actions/generate-podspec/action.yml
+++ b/.github/actions/generate-podspec/action.yml
@@ -15,4 +15,4 @@ runs:
       id: current
       shell: bash
       run: |
-        generate.sh ${{ inputs.version }} > ${{ inputs.podspec-path }}
+        ${{ github.action_path }}/generate.sh ${{ inputs.version }} > ${{ inputs.podspec-path }}

--- a/.github/actions/generate-podspec/action.yml
+++ b/.github/actions/generate-podspec/action.yml
@@ -1,0 +1,18 @@
+name: Generate podspec
+description: Generates a `.podspec` file with a given version number.
+inputs:
+  podspec-path:
+    description: The path of the generated podspec.
+    required: true
+  version:
+    description: The new version number.
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Get Current Version
+      id: current
+      shell: bash
+      run: |
+        generate.sh ${{ inputs.version }} > ${{ inputs.podspec-path }}

--- a/.github/actions/generate-podspec/generate.sh
+++ b/.github/actions/generate-podspec/generate.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env sh
+
+VERSION=$1
+
+cat  << EOF
+Pod::Spec.new do |s|
+    s.name             = 'BlueTriangleSDK-Swift'
+    s.version          = '$VERSION'
+    s.summary          = 'BlueTriangleSDK exposes methods to send analytics and crash data to the Blue Triangle portal'
+    s.description      = <<-DESC
+    BlueTriangleSDK exposes methods to send analytics and crash data to the Blue Triangle portal via HTTP Post
+                         DESC
+
+    s.homepage         = 'https://www.bluetriangle.com'
+    s.license          = { :type => 'MIT', :file => 'LICENSE.md' }
+    s.author           = { 'Blue Triangle SDK Support' => 'sdk-support@bluetriangle.com' }
+    s.source           = { :git => 'https://github.com/blue-triangle-tech/btt-swift-sdk.git', :tag => s.version.to_s }
+    s.social_media_url = 'https://twitter.com/_BlueTriangle'
+
+    s.module_name   = 'BlueTriangle'
+    s.swift_version = '5.5'
+
+    s.ios.deployment_target = '13.0'
+    s.osx.deployment_target = '10.15'
+    s.tvos.deployment_target = '13.0'
+    s.watchos.deployment_target = '6.0'
+
+    s.source_files = 'Sources/BlueTriangle/**/*.swift'
+
+  end
+EOF

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,3 +56,9 @@ jobs:
               ref: 'refs/tags/${{ steps.bump.outputs.version }}',
               sha: '${{ steps.commit.outputs.commit_hash }}'
             })
+
+      - name: Publish podspec
+        env:
+          COCOAPODS_TRUNK_TOKEN: ${{ secrets.COCOAPODS_TRUNK_TOKEN }}
+        run: |
+          pod trunk push ${{ env.PODSPEC-PATH }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,7 @@ on:
           - major
 
 env:
+  PODSPEC-PATH: 'BlueTriangleSDK-Swift.podspec'
   VERSION-FILE-PATH: 'Sources/BlueTriangle/Version.swift'
 
 jobs:
@@ -29,6 +30,12 @@ jobs:
         with:
           version-file-path: ${{ env.VERSION-FILE-PATH }}
           release-type: ${{ inputs.release_type }}
+
+      - name: Generate podspec
+        uses: ./.github/actions/generate-podspec
+        with:
+          podspec-path: ${{ env.PODSPEC-PATH }}
+          version: ${{ steps.bump.outputs.version }}
 
       - name: Commit Changes
         id: commit

--- a/BlueTriangleSDK-Swift.podspec
+++ b/BlueTriangleSDK-Swift.podspec
@@ -12,6 +12,7 @@ Pod::Spec.new do |s|
     s.source           = { :git => 'https://github.com/blue-triangle-tech/btt-swift-sdk.git', :tag => s.version.to_s }
     s.social_media_url = 'https://twitter.com/_BlueTriangle'
 
+    s.module_name   = 'BlueTriangle'
     s.swift_version = '5.5'
 
     s.ios.deployment_target = '13.0'

--- a/Tests/BlueTriangleTests/BlueTriangleTests.swift
+++ b/Tests/BlueTriangleTests/BlueTriangleTests.swift
@@ -231,7 +231,7 @@ extension BlueTriangleTests {
 
 // MARK: - Network Capture
 extension BlueTriangleTests {
-    func testNetworkCapture() throws {
+    func testNetworkCapture() async throws {
         Self.timeIntervals = [
             // BTTimer.start()
             6.0,
@@ -263,10 +263,10 @@ extension BlueTriangleTests {
 
         // Uploader
         var capturedRequest: Request!
-        let requestExpectation = self.expectation(description: "Request sent")
+        var requestExpectation: XCTestExpectation?
         let capturedRequestUploader = UploaderMock { req in
             capturedRequest = req
-            requestExpectation.fulfill()
+            requestExpectation?.fulfill()
         }
 
         // BlueTriangleConfiguration
@@ -295,12 +295,14 @@ extension BlueTriangleTests {
         let url: URL = "https://example.com/foo.json"
         let exp = expectation(description: "Requests completed")
         URLSession(configuration: .mock).btDataTask(with: url) { _, _, _ in exp.fulfill() }.resume()
-        wait(for: [exp], timeout: 1.0)
+        await waitForExpectations(timeout: 1.0)
+
+        requestExpectation = self.expectation(description: "Request sent")
 
         timer.end()
 
         _ = BlueTriangle.startTimer(page: Page(pageName: "Another_Page"))
-        wait(for: [requestExpectation], timeout: 1.0)
+        await waitForExpectations(timeout: 1.0)
 
         let capturedRequestString = String(data: Data(base64Encoded: capturedRequest.body!)!, encoding: .utf8)
         XCTAssertEqual(capturedRequestString, Mock.capturedRequestJSON)


### PR DESCRIPTION
When using the SDK via CocoaPods you must currently import `BlueTriangleSDK_Swift` rather than `BlueTriangle` as when using SPM. This adds `module_name` to the `.podspec` to enable importing `BlueTriangle` instead.

This also adds a GitHub action to generate the `.podspec` file with a given version number and updates the `Release` workflow to use that and to publish the podspec.

Finally, I updated `BlueTriangleTests.testNetworkCapture()` to make it `async` and use `XCTestCase.waitForExpectations(timeout:handler:)` to try and fix the sporadic test failure do to expectation timeouts on the GitHub runner.

**NOTE**: for the action to work `COCOAPODS_TRUNK_TOKEN` must be added to the repo secrets. You should be able to obtain your token by with the following command on the machine from which you initially registered via with CocoaPods: `grep -A2 'trunk.cocoapods.org' ~/.netrc`