### PR TITLE
Use macOS Runner for Release Workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ env:
 
 jobs:
   release:
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
     steps:
       - name: Git Checkout main
         uses: actions/checkout@v3


### PR DESCRIPTION
The `Publish podspec` step of the `Release` workflow fails because the Ubuntu runner does not support CocoaPods. This changes the workflow to run on macOS.