### PR TITLE
Add AnyCodable Type

### DIFF
--- a/Sources/BlueTriangle/Extensions/NSNumber+Utils.swift
+++ b/Sources/BlueTriangle/Extensions/NSNumber+Utils.swift
@@ -1,0 +1,30 @@
+//
+//  NSNumber+Utils.swift
+//
+//  Created by Mathew Gacy on 2/6/23.
+//  Copyright © 2023 Blue Triangle. All rights reserved.
+//
+
+import Foundation
+
+extension NSNumber {
+    enum NumberType: Equatable {
+        case bool(Bool)
+        case int(Int)
+        case double(Double)
+        case unknown
+    }
+
+    func numberType() -> NumberType {
+        switch CFNumberGetType(self) {
+        case .charType:
+            return .bool(self.boolValue)
+        case .sInt8Type, .sInt16Type, .sInt32Type, .sInt64Type, .shortType, .intType, .longType, .longLongType, .cfIndexType, .nsIntegerType:
+            return .int(self.intValue)
+        case .float32Type, .float64Type, .floatType, .doubleType, .cgFloatType:
+            return .double(self.doubleValue)
+        @unknown default:
+            return .unknown
+        }
+    }
+}

--- a/Sources/BlueTriangle/Models/AnyCodable.swift
+++ b/Sources/BlueTriangle/Models/AnyCodable.swift
@@ -1,0 +1,324 @@
+//
+//  AnyCodable.swift
+//
+//  Created by Mathew Gacy on 1/26/23.
+//  Copyright © 2023 Blue Triangle. All rights reserved.
+//
+
+import Foundation
+
+/// A wrapper for `Codable` values.
+public enum AnyCodable: Codable, Equatable, Hashable {
+
+    /// An error that occurs when trying to wrap a value in an ``AnyCodable`` instance.
+    public struct AnyCodableError: Error {
+        /// The reason for the error.
+        public let reason: String
+    }
+
+    /// A case representing a `nil` value.
+    case none
+    /// A case wrapping a `Bool` value.
+    case bool(Bool)
+    /// A case wrapping a `Double` value.
+    case double(Double)
+    /// A case wrapping an `Int` value.
+    case int(Int)
+    /// A case wrapping an `Int64` value.
+    ///
+    /// > Note: once encoded, `Int64` values will be decoded as `Int`s.
+    case int64(Int64)
+    /// A case wrapping a `UInt64` value.
+    case uint64(UInt64)
+    /// A case wrapping a `Date` value.
+    ///
+    /// > Note: date values should be encoded and decoded using an `iso8601` date encoding /
+    /// decoding strategy.
+    case date(Date)
+    /// A case wrapping a `URL` value.
+    ///
+    /// > Note: once encoded, `URL` values will be decoded as `String`s.
+    case url(URL)
+    /// A case wrapping a `String` value.
+    case string(String)
+    /// A case wrapping an `Array` of `AnyCodable` values.
+    case array([AnyCodable])
+    /// A case wrapping a `Dictionary` value.
+    case dictionary([String: AnyCodable])
+
+    /// Creates a new instance by wrapping the given NSNumber.
+    /// - Parameter value: The number to wrap.
+    public init(_ value: NSNumber) throws {
+        switch value.numberType() {
+        case .bool(let value):
+            self = .bool(value)
+        case .double(let value):
+            self = .double(value)
+        case .int(let value):
+            self = .int(value)
+        case .unknown:
+            throw AnyCodableError(reason: "Unable to wrap \(String(describing: value))")
+        }
+    }
+
+    /// Creates a new instance by wrapping the given value.
+    /// - Parameter value: The value to wrap.
+    public init(_ value: Any) throws {
+        switch value {
+        case Optional<Any>.none:
+            self = .none
+        case let bool as Bool:
+            self = .bool(bool)
+        case let double as Double:
+            self = .double(double)
+        case let int as Int:
+            self = .int(int)
+        case let int64 as Int64:
+            self = .int64(int64)
+        case let uint64 as UInt64:
+            self = .uint64(uint64)
+        case let date as Date:
+            self = .date(date)
+        case let url as URL:
+            self = .url(url)
+        case let string as String:
+            self = .string(string)
+        case let array as [Any]:
+            self = .array(try array.map(Self.init))
+        case let dictionary as [String: Any]:
+            self = .dictionary(try dictionary.mapValues(Self.init))
+        case let anyCodable as AnyCodable:
+            self = anyCodable
+        default:
+            throw AnyCodableError(reason: "Unable to wrap \(String(describing: value))")
+        }
+    }
+
+    /// Creates a new instance by decoding from the given decoder.
+    /// - Parameter decoder: The decoder to read data from.
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+
+        if container.decodeNil() {
+            self = .none
+        } else if let bool = try? container.decode(Bool.self) {
+            self = .bool(bool)
+        } else if let int = try? container.decode(Int.self) {
+            self = .int(int)
+        } else if let uint64 = try? container.decode(UInt64.self) {
+            self = .uint64(uint64)
+        } else if let double = try? container.decode(Double.self) {
+            self = .double(double)
+        } else if let date = try? container.decode(Date.self) {
+            self = .date(date)
+        } else if let string = try? container.decode(String.self) {
+            self = .string(string)
+        } else if let array = try? container.decode([Self].self) {
+            self =  .array(array)
+        } else if let dictionary = try? container.decode([String: Self].self) {
+            self = .dictionary(dictionary)
+        } else {
+            throw DecodingError.dataCorruptedError(in: container, debugDescription: "Unable to decode JSON")
+        }
+    }
+
+    /// Encodes this value into the given encoder.
+    /// - Parameter encoder: The encoder to write data to.
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+
+        switch self {
+        case .none:
+            try container.encodeNil()
+        case .bool(let value):
+            try container.encode(value)
+        case .double(let value):
+            try container.encode(value)
+        case .int(let value):
+            try container.encode(value)
+        case .int64(let value):
+            try container.encode(value)
+        case .uint64(let value):
+            try container.encode(value)
+        case .date(let value):
+            try container.encode(value)
+        case .url(let value):
+            try container.encode(value)
+        case .string(let value):
+            try container.encode(value)
+        case .array(let value):
+            try container.encode(value)
+        case .dictionary(let value):
+            try container.encode(value)
+        }
+    }
+}
+
+// MARK: - Associated Value Access
+public extension AnyCodable {
+    /// The type-erased wrapped value.
+    var anyValue: Any? {
+        switch self {
+        case .none:
+            return nil
+        case .bool(let bool):
+            return bool as Any
+        case .double(let double):
+            return double as Any
+        case .int(let int):
+            return int as Any
+        case .int64(let int64):
+            return int64 as Any
+        case .uint64(let uint64):
+            return uint64 as Any
+        case .date(let date):
+            return date as Any
+        case .url(let url):
+            return url as Any
+        case .string(let string):
+            return string as Any
+        case .array(let array):
+            return array.compactMap { $0.anyValue } as Any
+        case .dictionary(let dictionary):
+            return dictionary.compactMapValues { $0.anyValue } as Any
+        }
+    }
+
+    /// The wrapped array if one exists.
+    var arrayValue: [AnyCodable]? {
+        switch self {
+        case .array(let array): return array
+        default: return nil
+        }
+    }
+
+    /// The wrapped Boolean if one exists.
+    var boolValue: Bool? {
+        switch self {
+        case .bool(let bool): return bool
+        default: return nil
+        }
+    }
+
+    /// The wrapped date if one exists.
+    var dateValue: Date? {
+        switch self {
+        case .date(let date): return date
+        default: return nil
+        }
+    }
+
+    /// The wrapped dictionary if one exists.
+    var dictionaryValue: [String: AnyCodable]? {
+        switch self {
+        case .dictionary(let dictionary): return dictionary
+        default: return nil
+        }
+    }
+
+    /// The wrapped double if one exists.
+    var doubleValue: Double? {
+        switch self {
+        case .double(let double): return double
+        default: return nil
+        }
+    }
+
+    /// The wrapped integer if one exists.
+    var intValue: Int? {
+        switch self {
+        case .int(let int): return int
+        default: return nil
+        }
+    }
+
+    /// The wrapped `Int64` if one exists.
+    var int64Value: Int64? {
+        switch self {
+        case .int64(let int64): return int64
+        default: return nil
+        }
+    }
+
+    /// The wrapped string if one exists.
+    var stringValue: String? {
+        switch self {
+        case .string(let string): return string
+        default: return nil
+        }
+    }
+
+    /// The wrapped `UIint64` if one exists.
+    var uint64Value: UInt64? {
+        switch self {
+        case .uint64(let uint64): return uint64
+        default: return nil
+        }
+    }
+
+    /// The wrapped URL if one exists.
+    var urlValue: URL? {
+        switch self {
+        case .url(let url): return url
+        default: return nil
+        }
+    }
+}
+
+// MARK: - ExpressibleBy Protocols
+extension AnyCodable: ExpressibleByArrayLiteral {
+    /// Creates an instance initialized with the given elements.
+    /// - Parameter elements: The elements of the new instance.
+    public init(arrayLiteral elements: AnyCodable...) {
+        self = .array(elements)
+    }
+}
+
+extension AnyCodable: ExpressibleByBooleanLiteral {
+    /// Creates an instance initialized to the given Boolean value.
+    /// - Parameter value: The value of the new instance.
+    public init(booleanLiteral value: Bool) {
+        self = .bool(value)
+    }
+}
+
+extension AnyCodable: ExpressibleByDictionaryLiteral {
+    /// Creates an instance initialized with the given key-value pairs.
+    /// - Parameter elements: The key-value pairs of the new instance.
+    public init(dictionaryLiteral elements: (String, AnyCodable)...) {
+        self = .dictionary(.init(elements, uniquingKeysWith: { first, _ in first }))
+    }
+}
+
+extension AnyCodable: ExpressibleByFloatLiteral {
+    /// Creates an instance initialized to the specified floating-point value.
+    /// - Parameter value: The value to create.
+    public init(floatLiteral value: Double) {
+        self = .double(value)
+    }
+}
+
+extension AnyCodable: ExpressibleByIntegerLiteral {
+    /// Creates an instance initialized to the specified integer value.
+    /// - Parameter value: The value to create.
+    public init(integerLiteral value: Int) {
+        self = .int(value)
+    }
+}
+
+extension AnyCodable: ExpressibleByNilLiteral {
+    /// Creates an instance initialized with `nil`.
+    public init(nilLiteral: ()) {
+        self = .none
+    }
+}
+
+extension AnyCodable: ExpressibleByStringLiteral {
+    /// Creates an instance initialized to the given string value.
+    /// - Parameter value: The value of the new instance.
+    public init(stringLiteral value: String) {
+        self = .string(value)
+    }
+}
+
+extension AnyCodable: ExpressibleByStringInterpolation {}

--- a/Tests/BlueTriangleTests/AnyCodableTests.swift
+++ b/Tests/BlueTriangleTests/AnyCodableTests.swift
@@ -1,0 +1,348 @@
+//
+//  AnyCodableTests.swift
+//
+//  Created by Mathew Gacy on 1/26/23.
+//  Copyright © 2023 Blue Triangle. All rights reserved.
+//
+
+@testable import BlueTriangle
+import XCTest
+
+final class AnyCodableTests: XCTestCase {
+    let array: [String] = ["a", "b", "c"]
+    let bool: Bool = true
+    let date = Date(timeIntervalSince1970: 1670000000)
+    let double: Double = 9.99
+    let float: Float = 11.11
+    let int: Int = 9
+    let int64: Int64 = .max
+    let string: String = "String"
+    let uint64: UInt64 = .max
+    let url: URL = "https://example.com/foo"
+
+    var dictionary: [String: Any] {
+        [
+            "string": string,
+            "bool": bool,
+            "double": double,
+            "int": int,
+            "array": array,
+            "nested": [
+                "foo": "bar"
+            ]
+        ]
+    }
+
+    var decoder: JSONDecoder {
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        return decoder
+    }
+
+    var encoder: JSONEncoder {
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        return encoder
+    }
+
+    func encodeAndDecode<T: Codable>(_ value: Any) throws -> T? {
+        let anyCodable = try AnyCodable(value)
+        let encoded = try encoder.encode(anyCodable)
+        let decoded = try decoder.decode(AnyCodable.self, from: encoded)
+        return decoded.anyValue as? T
+    }
+}
+
+// MARK: - Type -> Encoded -> Decoded -> Any -> Type
+extension AnyCodableTests {
+    func testArrayOfDoublesCoding() throws {
+        let expectedValue: [Double] = [1.1, 2.22, 3.333]
+        let actualValue: [Double]? = try encodeAndDecode(expectedValue)
+        XCTAssertEqual(actualValue, expectedValue)
+    }
+
+    func testArrayOfStringsCoding() throws {
+        let expectedValue = ["a", "b", "c"]
+        let actualValue: [String]? = try encodeAndDecode(expectedValue)
+        XCTAssertEqual(actualValue, expectedValue)
+    }
+
+    func testBoolCoding() throws {
+        let expectedValue = true
+        let actualValue: Bool? = try encodeAndDecode(expectedValue)
+        XCTAssertEqual(actualValue, expectedValue)
+    }
+
+    func testDateCoding() throws {
+        let expectedValue = Date(timeIntervalSince1970: 1670000000)
+        let actualValue: Date? = try encodeAndDecode(expectedValue)
+        XCTAssertEqual(actualValue, expectedValue)
+    }
+
+    func testDictionaryCoding() throws {
+        let expectedValue = ["foo": "bar"]
+        let actualValue: [String: String]? = try encodeAndDecode(expectedValue)
+        XCTAssertEqual(actualValue, expectedValue)
+    }
+
+    func testDictionaryOfAnyCoding() throws {
+        let initialValue: [String: Any] = [
+            "string": string,
+            "bool": bool,
+            "int": int,
+            "double": double,
+            "array": array,
+            "dictionary": [
+                "foo": 11
+            ]
+        ]
+
+        let anyCodable = try AnyCodable(initialValue)
+
+        let encoded = try encoder.encode(anyCodable)
+        let decoded = try decoder.decode(AnyCodable.self, from: encoded)
+        let anyDictionary = decoded.anyValue as! [String: Any]
+
+        XCTAssertEqual(anyDictionary["string"] as! String , string)
+        XCTAssertEqual(anyDictionary["int"] as! Int , int)
+        XCTAssertEqual(anyDictionary["double"] as! Double , double)
+        XCTAssertEqual(anyDictionary["bool"] as! Bool , bool)
+        XCTAssertEqual(anyDictionary["array"] as! [String] , array)
+
+        let nestedDictionary = anyDictionary["dictionary"] as! [String: Any]
+        XCTAssertEqual(nestedDictionary["foo"] as! Int, 11)
+    }
+
+    func testDoubleCoding() throws {
+        let expectedValue: Double = 9.99
+        let actualValue: Double? = try encodeAndDecode(expectedValue)
+        XCTAssertEqual(actualValue, expectedValue)
+    }
+
+    func testIntCoding() throws {
+        let expectedValue: Int = 9
+        let actualValue: Int? = try encodeAndDecode(expectedValue)
+        XCTAssertEqual(actualValue, expectedValue)
+    }
+
+    func testInt64Coding() throws {
+        let expectedValue: Int64 = Int64.max
+        let actualValue: Int? = try encodeAndDecode(expectedValue)
+        XCTAssertEqual(actualValue, Int(expectedValue))
+    }
+
+    func testNilCoding() throws {
+        let expectedValue: String? = nil
+        let actualValue: String? = try encodeAndDecode(expectedValue as Any)
+        XCTAssertEqual(actualValue, expectedValue)
+    }
+
+    func testStringCoding() throws {
+        let expectedValue = "Example string"
+        let actualValue: String? = try encodeAndDecode(expectedValue)
+        XCTAssertEqual(actualValue, expectedValue)
+    }
+
+    func testUInt64Coding() throws {
+        let expectedValue: UInt64 = UInt64.max
+        let actualValue: UInt64? = try encodeAndDecode(expectedValue)
+        XCTAssertEqual(actualValue, expectedValue)
+    }
+
+    func testURLCoding() throws {
+        let urlString = "https://example.com"
+        let expectedValue = URL(string: urlString)!
+        let actualValue: String? = try encodeAndDecode(expectedValue)
+        XCTAssertEqual(actualValue, urlString)
+    }
+}
+
+// MARK: - Bridged Types
+extension AnyCodableTests {
+    func testArrayBridging() throws {
+        let nsArray = NSArray(array: ["a", "b", "c"])
+        let anyCodable = try AnyCodable(nsArray)
+        XCTAssertEqual(anyCodable, .array(["a", "b", "c"]))
+        XCTAssertEqual(anyCodable.anyValue as? NSArray, nsArray)
+    }
+
+    func testDateBridging() throws {
+        let nsDate = NSDate(timeIntervalSince1970: 1670000000)
+        let anyCodable = try AnyCodable(nsDate)
+        XCTAssertEqual(anyCodable, .date(date))
+        XCTAssertEqual(anyCodable.anyValue as? NSDate, nsDate)
+    }
+
+    func testDictionaryBridging() throws {
+        let nsDictionary: NSDictionary = [
+            "foo": "bar",
+            "array": [2.0, 3.0, 4.0]
+        ]
+        let anyCodable = try AnyCodable(nsDictionary)
+        XCTAssertEqual(anyCodable, ["foo": .string("bar"), "array": [.double(2.0), .double(3.0), .double(4.0)]])
+        XCTAssertEqual(anyCodable.anyValue as? NSDictionary, nsDictionary)
+    }
+
+    func testNumberBridging() throws {
+        let nsBool = NSNumber(value: bool)
+        let wrappedBool = try AnyCodable(nsBool)
+        XCTAssertEqual(wrappedBool, .bool(bool))
+        XCTAssertEqual(wrappedBool.anyValue as? NSNumber, nsBool)
+
+        let nsDouble = NSNumber(value: double)
+        let wrappedDouble = try AnyCodable(nsDouble)
+        XCTAssertEqual(wrappedDouble, .double(double))
+        XCTAssertEqual(wrappedDouble.anyValue as? NSNumber, nsDouble)
+
+        let nsFloat = NSNumber(value: float)
+        let wrappedFloat = try AnyCodable(nsFloat)
+        XCTAssertEqual(wrappedFloat, .double(Double(float)))
+        XCTAssertEqual(wrappedFloat.anyValue as? NSNumber, nsFloat)
+
+        let nsInt = NSNumber(value: int)
+        let wrappedInt = try AnyCodable(nsInt)
+        XCTAssertEqual(wrappedInt, .int(int))
+        XCTAssertEqual(wrappedInt.anyValue as? NSNumber, nsInt)
+    }
+
+    func testStringBridging() throws {
+        let nsString = NSString(string: string)
+        let anyCodable = try AnyCodable(nsString)
+        XCTAssertEqual(anyCodable, .string(string))
+        XCTAssertEqual(anyCodable.anyValue as? NSString, nsString)
+    }
+}
+
+// MARK: - Associated Value Access
+extension AnyCodableTests {
+    func testArrayValue() throws {
+        let expectedValue: [AnyCodable] = ["a", "b", "c"]
+        let sut = try AnyCodable(array)
+        let actualValue = sut.arrayValue
+        XCTAssertEqual(actualValue, expectedValue)
+    }
+
+    func testBoolValue() throws {
+        let sut = try AnyCodable(bool)
+        let actualValue = sut.boolValue
+        XCTAssertEqual(actualValue, bool)
+    }
+
+    func testDateValue() throws {
+        let sut = try AnyCodable(date)
+        let actualValue = sut.dateValue
+        XCTAssertEqual(actualValue, date)
+    }
+
+    func testDictionaryValue() throws {
+        let sut = try AnyCodable(dictionary)
+        let actualValue = sut.dictionaryValue!
+
+        XCTAssertEqual(actualValue["string"], .string(string))
+        XCTAssertEqual(actualValue["bool"], .bool(bool))
+        XCTAssertEqual(actualValue["double"], .double(double))
+        XCTAssertEqual(actualValue["int"], .int(int))
+        XCTAssertEqual(actualValue["array"], .array(["a", "b", "c"]))
+        XCTAssertEqual(actualValue["nested"], .dictionary(["foo": "bar"]))
+    }
+
+    func testDoubleValue() throws {
+        let sut = try AnyCodable(double)
+        let actualValue = sut.doubleValue
+        XCTAssertEqual(actualValue, double)
+    }
+
+    func testIntValue() throws {
+        let sut = try AnyCodable(int)
+        let actualValue = sut.intValue
+        XCTAssertEqual(actualValue, int)
+    }
+
+    func testInt64Value() throws {
+        let sut = try AnyCodable(int64)
+        let actualValue = sut.int64Value
+        XCTAssertEqual(actualValue, int64)
+    }
+
+    func testStringValue() throws {
+        let sut = try AnyCodable(string)
+        let actualValue = sut.stringValue
+        XCTAssertEqual(actualValue, string)
+    }
+
+    func testUInt64Value() throws {
+        let sut = try AnyCodable(uint64)
+        let actualValue = sut.uint64Value
+        XCTAssertEqual(actualValue, uint64)
+    }
+
+    func testURLValue() throws {
+        let sut = try AnyCodable(url)
+        let actualValue = sut.urlValue
+        XCTAssertEqual(actualValue, url)
+    }
+}
+
+// MARK: - ExpressibleBy
+extension AnyCodableTests {
+    func testArrayExpressibility() {
+        let sut: AnyCodable = ["a", "b", "c"]
+        XCTAssertEqual(sut, .array([.string("a"), .string("b"), .string("c")]))
+    }
+
+    func testBooleanExpressibility() {
+        let sut: AnyCodable = true
+        XCTAssertEqual(sut, .bool(true))
+    }
+
+    func testDictionaryExpressibility() {
+        let sut: AnyCodable = ["foo": "bar"]
+        XCTAssertEqual(sut, .dictionary(["foo": .string("bar")]))
+    }
+
+    func testFloatExpressibility() {
+        let sut: AnyCodable = 9.99
+        XCTAssertEqual(sut, .double(9.99))
+    }
+
+    func testIntegerExpressibility() {
+        let sut: AnyCodable = 9
+        XCTAssertEqual(sut, .int(9))
+    }
+
+    func testNilExpressibility() {
+        let sut: AnyCodable = nil
+        XCTAssertEqual(sut, .none)
+    }
+
+    func testStringExpressibility() {
+        let sut: AnyCodable = "String"
+        XCTAssertEqual(sut, .string("String"))
+    }
+
+    func testStringInterpolationExpressibility() {
+        let value = 4
+        let sut: AnyCodable = "The value is \(value)"
+        XCTAssertEqual(sut, .string("The value is 4"))
+    }
+}
+
+extension AnyCodableTests {
+    func testInitialzeWithAnyCodable() throws {
+        let inner = try AnyCodable(string)
+        let outer = try AnyCodable(inner)
+        XCTAssertEqual(outer, inner)
+    }
+
+    func testAnyInt64Value() throws {
+        let sut = try AnyCodable(int64)
+        let actual = sut.anyValue as? Int64
+        XCTAssertEqual(actual, int64)
+    }
+
+    func testAnyURLValue() throws {
+        let sut = try AnyCodable(url)
+        let actual = sut.anyValue as? URL
+        XCTAssertEqual(actual, url)
+    }
+}

--- a/Tests/BlueTriangleTests/UtilityTests.swift
+++ b/Tests/BlueTriangleTests/UtilityTests.swift
@@ -1,0 +1,44 @@
+//
+//  UtilityTests.swift
+//
+//  Created by Mathew Gacy on 2/6/23.
+//  Copyright © 2023 Blue Triangle. All rights reserved.
+//
+
+@testable import BlueTriangle
+import XCTest
+
+final class UtilityTests: XCTestCase {}
+
+// MARK: - NSNumber+Utils
+extension UtilityTests {
+    func testBoolIdentification() {
+        let bool: Bool = true
+        let nsNumber = NSNumber(value: bool)
+        XCTAssertEqual(nsNumber.numberType(), .bool(bool))
+    }
+
+    func testDoubleIdentification() {
+        let double: Double = 9.99
+        let nsNumber = NSNumber(value: double)
+        XCTAssertEqual(nsNumber.numberType(), .double(double))
+    }
+
+    func testFloatIdentification() {
+        let float: Float = 11.11
+        let nsNumber = NSNumber(value: float)
+        XCTAssertEqual(nsNumber.numberType(), .double(Double(float)))
+    }
+
+    func testIntIdentification() {
+        let int: Int = 9
+        let nsNumber = NSNumber(value: int)
+        XCTAssertEqual(nsNumber.numberType(), .int(int))
+    }
+
+    func testInt64Identification() {
+        let int64: Int64 = .max
+        let nsNumber = NSNumber(value: int64)
+        XCTAssertEqual(nsNumber.numberType(), .int(Int(int64)))
+    }
+}


### PR DESCRIPTION
Adds `AnyCodable` type to add `Codable` conformance to `Any`. Note that despite the common name this uses a different strategy than the `AnyCodable` package, which stores the wrapped value as `Any`. 

The next PR will use a `Dictionary<String, AnyCodable` to store custom metrics.

This also adds an internal `NSNumber.NumberType` and `NSNumber.numberType()` method to help with handling the data type of `NSNumber`s.