### PR TITLE
Add Custom Metrics to Timer Requests

### DIFF
--- a/Sources/BlueTriangle/BTLogger.swift
+++ b/Sources/BlueTriangle/BTLogger.swift
@@ -95,6 +95,15 @@ final class BTLogger: Logging {
         logger.log(level: .info, message: message, file: file, function: function, line: line)
     }
 
+    func logDefault(
+        _ message: @escaping () -> String,
+        file: StaticString,
+        function: StaticString,
+        line: UInt
+    ) {
+        logger.log(level: .default, message: message, file: file, function: function, line: line)
+    }
+
     func logError(
         _ message: @escaping () -> String,
         file: StaticString,

--- a/Sources/BlueTriangle/BlueTriangleConfiguration.swift
+++ b/Sources/BlueTriangle/BlueTriangleConfiguration.swift
@@ -91,9 +91,11 @@ final public class BlueTriangleConfiguration: NSObject {
 
     var capturedRequestCollectorConfiguration: CapturedRequestCollector.Configuration = .live
 
-    var requestBuilder: TimerRequestBuilder = .live
-
     var performanceMonitorBuilder: PerformanceMonitorBuilder = .live
+
+    lazy var requestBuilder: TimerRequestBuilder = {
+        TimerRequestBuilder.live(logger: makeLogger())
+    }()
 }
 
 // MARK: - Supporting Types

--- a/Sources/BlueTriangle/Byte.swift
+++ b/Sources/BlueTriangle/Byte.swift
@@ -1,0 +1,19 @@
+//
+//  Byte.swift
+//
+//  Created by Mathew Gacy on 2/14/23.
+//  Copyright © 2023 Blue Triangle. All rights reserved.
+//
+
+import Foundation
+
+typealias Byte = UInt8
+
+/// Adds control character conveniences.
+extension Byte {
+    /// {
+    static let leftCurlyBracket: Byte = 0x7B
+
+    /// }
+    static let rightCurlyBracket: Byte = 0x7D
+}

--- a/Sources/BlueTriangle/Constants.swift
+++ b/Sources/BlueTriangle/Constants.swift
@@ -33,6 +33,11 @@ enum Constants {
     static let excludedValue = "20"
     static let startupDelay: TimeInterval = 10
 
+    // Custom Metrics
+    static let metricsCharacterLimit = 1024
+    static let metricsSizeLimit = 3_000_000
+    static let metricsCodingKey = "ECV"
+
     // Logging
     static let loggingSubsystem = "com.bluetriangle.sdk"
     static let loggingCategory = "tracker"

--- a/Sources/BlueTriangle/Extensions/Data+Utils.swift
+++ b/Sources/BlueTriangle/Extensions/Data+Utils.swift
@@ -8,6 +8,10 @@
 import Foundation
 
 extension Data {
+    enum JSONError: Error {
+        case invalidDataType
+    }
+
     var prettyJson: String? {
         guard let object = try? JSONSerialization.jsonObject(with: self, options: []),
               let data = try? JSONSerialization.data(withJSONObject: object, options: [.prettyPrinted]),
@@ -20,5 +24,17 @@ extension Data {
 
     func base64DecodedData(options: Data.Base64DecodingOptions = []) -> Data? {
         Data(base64Encoded: self, options: options)
+    }
+
+    mutating func append(objectData: Data, key: String) throws {
+        guard first == .leftCurlyBracket, last == .rightCurlyBracket else {
+            throw JSONError.invalidDataType
+        }
+
+        removeLast()
+        let keyData = Data(",\"\(key)\":".utf8)
+        append(keyData)
+        append(objectData)
+        append(.rightCurlyBracket)
     }
 }

--- a/Sources/BlueTriangle/Models/AnyCodable.swift
+++ b/Sources/BlueTriangle/Models/AnyCodable.swift
@@ -29,6 +29,9 @@ public enum AnyCodable: Codable, Equatable, Hashable {
     /// > Note: once encoded, `Int64` values will be decoded as `Int`s.
     case int64(Int64)
     /// A case wrapping a `UInt64` value.
+    ///
+    /// > Note: once encoded, `UInt64` values that fall within the range of allowable `Int64`
+    /// values will be decoded as `Int64`.
     case uint64(UInt64)
     /// A case wrapping a `Date` value.
     ///

--- a/Sources/BlueTriangle/Models/Session.swift
+++ b/Sources/BlueTriangle/Models/Session.swift
@@ -46,4 +46,7 @@ struct Session: Equatable {
 
     /// Traffic segment.
     var trafficSegmentName: String
+
+    /// Custom metrics.
+    var metrics: [String: AnyCodable]?
 }

--- a/Sources/BlueTriangle/Models/TimerRequest.swift
+++ b/Sources/BlueTriangle/Models/TimerRequest.swift
@@ -60,7 +60,6 @@ extension TimerRequest: Codable {
         try con.encode(session.campaignSource, forKey: .campaignSource)
         try con.encode(session.dataCenter, forKey: .dataCenter)
         try con.encode(session.trafficSegmentName, forKey: .trafficSegmentName)
-        try con.encode(session.metrics, forKey: .customMetrics)
 
         // Page
         try con.encode(page.brandValue, forKey: .brandValue)
@@ -159,8 +158,7 @@ extension TimerRequest: Codable {
             campaignName: try container.decode(String.self, forKey: CodingKeys.campaignName),
             campaignSource: try container.decode(String.self, forKey: CodingKeys.campaignSource),
             dataCenter: try container.decode(String.self, forKey: CodingKeys.dataCenter),
-            trafficSegmentName: try container.decode(String.self, forKey: CodingKeys.trafficSegmentName),
-            metrics: try container.decodeIfPresent([String: AnyCodable].self, forKey: CodingKeys.customMetrics))
+            trafficSegmentName: try container.decode(String.self, forKey: CodingKeys.trafficSegmentName))
 
         // CustomVariables
         let customVariables = CustomVariables(
@@ -280,7 +278,6 @@ extension TimerRequest: Codable {
         case campaignSource = "CmpS"
         case dataCenter = "DCTR"
         case trafficSegmentName = "txnName"
-        case customMetrics = "ECV"
         // Page
         case brandValue = "bv"
         case pageName

--- a/Sources/BlueTriangle/Models/TimerRequest.swift
+++ b/Sources/BlueTriangle/Models/TimerRequest.swift
@@ -60,6 +60,7 @@ extension TimerRequest: Codable {
         try con.encode(session.campaignSource, forKey: .campaignSource)
         try con.encode(session.dataCenter, forKey: .dataCenter)
         try con.encode(session.trafficSegmentName, forKey: .trafficSegmentName)
+        try con.encode(session.metrics, forKey: .customMetrics)
 
         // Page
         try con.encode(page.brandValue, forKey: .brandValue)
@@ -158,7 +159,8 @@ extension TimerRequest: Codable {
             campaignName: try container.decode(String.self, forKey: CodingKeys.campaignName),
             campaignSource: try container.decode(String.self, forKey: CodingKeys.campaignSource),
             dataCenter: try container.decode(String.self, forKey: CodingKeys.dataCenter),
-            trafficSegmentName: try container.decode(String.self, forKey: CodingKeys.trafficSegmentName))
+            trafficSegmentName: try container.decode(String.self, forKey: CodingKeys.trafficSegmentName),
+            metrics: try container.decodeIfPresent([String: AnyCodable].self, forKey: CodingKeys.customMetrics))
 
         // CustomVariables
         let customVariables = CustomVariables(
@@ -278,6 +280,7 @@ extension TimerRequest: Codable {
         case campaignSource = "CmpS"
         case dataCenter = "DCTR"
         case trafficSegmentName = "txnName"
+        case customMetrics = "ECV"
         // Page
         case brandValue = "bv"
         case pageName

--- a/Sources/BlueTriangle/Protocols/Logging.swift
+++ b/Sources/BlueTriangle/Protocols/Logging.swift
@@ -24,6 +24,13 @@ protocol Logging {
         line: UInt
     )
 
+    func logDefault(
+        _ message: @escaping () -> String,
+        file: StaticString,
+        function: StaticString,
+        line: UInt
+    )
+
     func logError(
         _ message: @escaping () -> String,
         file: StaticString,
@@ -49,6 +56,15 @@ extension Logging {
         line: UInt = #line
     ) {
         logInfo(message, file: file, function: function, line: line)
+    }
+
+    func log(
+        _ message: @autoclosure @escaping () -> String,
+        file: StaticString = #fileID,
+        function: StaticString = #function,
+        line: UInt = #line
+    ) {
+        logDefault(message, file: file, function: function, line: line)
     }
 
     func error(

--- a/Sources/BlueTriangle/TimerRequestBuilder.swift
+++ b/Sources/BlueTriangle/TimerRequestBuilder.swift
@@ -10,15 +10,49 @@ import Foundation
 struct TimerRequestBuilder {
     let builder: (Session, BTTimer, PurchaseConfirmation?) throws -> Request
 
-    static let live = TimerRequestBuilder { session, timer, purchase in
-        let model = TimerRequest(session: session,
-                                 page: timer.page,
-                                 timer: timer.pageTimeInterval,
-                                 purchaseConfirmation: purchase,
-                                 performanceReport: timer.performanceReport)
-        return try Request(method: .post,
+    static func live(logger: Logging) -> Self {
+        let encodeer = JSONEncoder()
+
+        return .init { session, timer, purchase in
+            let request = TimerRequest(session: session,
+                                       page: timer.page,
+                                       timer: timer.pageTimeInterval,
+                                       purchaseConfirmation: purchase,
+                                       performanceReport: timer.performanceReport)
+
+            var requestData = try encodeer.encode(request)
+            if let metrics = session.metrics {
+                do {
+                    let metricsData = try encodeer.encode(metrics)
+
+                    let metricsString = String(decoding: metricsData, as: UTF8.self)
+                    if metricsString.count > Constants.metricsCharacterLimit {
+                        logger.error("Custom metrics length is \(metricsString.count) characters; exceeding \(Constants.metricsCharacterLimit) results in data loss.")
+                    }
+
+                    let base64MetricsData = metricsData.base64EncodedData()
+                    if base64MetricsData.count > Constants.metricsSizeLimit {
+                        let bcf = ByteCountFormatter()
+                        bcf.includesActualByteCount = true
+
+                        func formatted(_ count: Int) -> String {
+                            bcf.string(fromByteCount: Int64(count))
+                        }
+
+                        logger.error("Custom metrics encoded size of \(formatted(base64MetricsData.count)) exceeds limit of \(formatted(Constants.metricsSizeLimit)); dropping from timer request.")
+                    } else {
+                        try requestData.append(objectData: metricsData, key: Constants.metricsCodingKey)
+                    }
+
+                } catch {
+                    logger.error("Custom metrics encoding failed: \(error.localizedDescription)")
+                }
+            }
+
+            return Request(method: .post,
                            url: Constants.timerEndpoint,
                            headers: nil,
-                           model: model)
+                           body: requestData)
+        }
     }
 }

--- a/Sources/BlueTriangle/TimerRequestBuilder.swift
+++ b/Sources/BlueTriangle/TimerRequestBuilder.swift
@@ -11,7 +11,7 @@ struct TimerRequestBuilder {
     let builder: (Session, BTTimer, PurchaseConfirmation?) throws -> Request
 
     static func live(logger: Logging) -> Self {
-        let encodeer = JSONEncoder()
+        let encoder = JSONEncoder()
 
         return .init { session, timer, purchase in
             let request = TimerRequest(session: session,
@@ -20,10 +20,10 @@ struct TimerRequestBuilder {
                                        purchaseConfirmation: purchase,
                                        performanceReport: timer.performanceReport)
 
-            var requestData = try encodeer.encode(request)
+            var requestData = try encoder.encode(request)
             if let metrics = session.metrics {
                 do {
-                    let metricsData = try encodeer.encode(metrics)
+                    let metricsData = try encoder.encode(metrics)
 
                     let base64MetricsData = metricsData.base64EncodedData()
                     if base64MetricsData.count > Constants.metricsSizeLimit {

--- a/Sources/BlueTriangle/TimerRequestBuilder.swift
+++ b/Sources/BlueTriangle/TimerRequestBuilder.swift
@@ -34,18 +34,18 @@ struct TimerRequestBuilder {
                             bcf.string(fromByteCount: Int64(count))
                         }
 
-                        logger.error("Custom metrics encoded size of \(formatted(base64MetricsData.count)) exceeds limit of \(formatted(Constants.metricsSizeLimit)); dropping from timer request.")
+                        logger.log("Custom metrics encoded size of \(formatted(base64MetricsData.count)) exceeds limit of \(formatted(Constants.metricsSizeLimit)); dropping from timer request.")
                     } else {
                         let metricsString = String(decoding: metricsData, as: UTF8.self)
                         if metricsString.count > Constants.metricsCharacterLimit {
-                            logger.error("Custom metrics length is \(metricsString.count) characters; exceeding \(Constants.metricsCharacterLimit) results in data loss.")
+                            logger.log("Custom metrics length is \(metricsString.count) characters; exceeding \(Constants.metricsCharacterLimit) results in data loss.")
                         }
 
                         try requestData.append(objectData: metricsData, key: Constants.metricsCodingKey)
                     }
 
                 } catch {
-                    logger.error("Custom metrics encoding failed: \(error.localizedDescription)")
+                    logger.log("Custom metrics encoding failed: \(error.localizedDescription)")
                 }
             }
 

--- a/Sources/BlueTriangle/TimerRequestBuilder.swift
+++ b/Sources/BlueTriangle/TimerRequestBuilder.swift
@@ -25,11 +25,6 @@ struct TimerRequestBuilder {
                 do {
                     let metricsData = try encodeer.encode(metrics)
 
-                    let metricsString = String(decoding: metricsData, as: UTF8.self)
-                    if metricsString.count > Constants.metricsCharacterLimit {
-                        logger.error("Custom metrics length is \(metricsString.count) characters; exceeding \(Constants.metricsCharacterLimit) results in data loss.")
-                    }
-
                     let base64MetricsData = metricsData.base64EncodedData()
                     if base64MetricsData.count > Constants.metricsSizeLimit {
                         let bcf = ByteCountFormatter()
@@ -41,6 +36,11 @@ struct TimerRequestBuilder {
 
                         logger.error("Custom metrics encoded size of \(formatted(base64MetricsData.count)) exceeds limit of \(formatted(Constants.metricsSizeLimit)); dropping from timer request.")
                     } else {
+                        let metricsString = String(decoding: metricsData, as: UTF8.self)
+                        if metricsString.count > Constants.metricsCharacterLimit {
+                            logger.error("Custom metrics length is \(metricsString.count) characters; exceeding \(Constants.metricsCharacterLimit) results in data loss.")
+                        }
+
                         try requestData.append(objectData: metricsData, key: Constants.metricsCodingKey)
                     }
 

--- a/Tests/BlueTriangleTests/BlueTriangleTests.swift
+++ b/Tests/BlueTriangleTests/BlueTriangleTests.swift
@@ -56,6 +56,7 @@ final class BlueTriangleTests: XCTestCase {
 
     override func tearDown() {
         super.tearDown()
+        Self.timeIntervals = []
         Self.onMakeTimer = { _, _ in }
         Self.onBuildRequest = { _, _, _ in }
         Self.onSendRequest = { _ in }
@@ -358,7 +359,6 @@ extension BlueTriangleTests {
         waitForExpectations(timeout: 10.0)
 
         XCTAssertNotNil(finishedTimer)
-        print(performanceMonitor.measurements)
 
         let base64Decoded = Data(base64Encoded: request.body!)!
         let performanceReport = try JSONDecoder().decode(TimerRequest.self, from: base64Decoded).performanceReport!

--- a/Tests/BlueTriangleTests/BlueTriangleTests.swift
+++ b/Tests/BlueTriangleTests/BlueTriangleTests.swift
@@ -82,12 +82,7 @@ extension BlueTriangleTests {
         // Performance Monitor
         let performanceStartExpectation = expectation(description: "Performance monitoring started")
         let performanceEndExpectation = expectation(description: "Performance monitoring ended")
-        let expectedReport = PerformanceReport(minCPU: 1.0,
-                                               maxCPU: 100.0,
-                                               avgCPU: 50.0,
-                                               minMemory: 10000000,
-                                               maxMemory: 100000000,
-                                               avgMemory: 50000000)
+        let expectedReport = Mock.performanceReport
 
         Self.performanceMonitor.report = expectedReport
         Self.performanceMonitor.onStart = { performanceStartExpectation.fulfill() }

--- a/Tests/BlueTriangleTests/Mocks/LoggerMock.swift
+++ b/Tests/BlueTriangleTests/Mocks/LoggerMock.swift
@@ -12,17 +12,20 @@ class LoggerMock: Logging {
     var enableDebug: Bool
     var onDebug: (String) -> Void
     var onInfo: (String) -> Void
+    var onDefault: (String) -> Void
     var onError: (String) -> Void
 
     init(
         enableDebug: Bool = false,
         onDebug: @escaping (String) -> Void = { _ in },
         onInfo: @escaping (String) -> Void = { _ in },
+        onDefault: @escaping (String) -> Void = { _ in },
         onError: @escaping (String) -> Void = { _ in }
     ) {
         self.enableDebug = enableDebug
         self.onDebug = onDebug
         self.onInfo = onInfo
+        self.onDefault = onDefault
         self.onError = onError
     }
 
@@ -34,6 +37,10 @@ class LoggerMock: Logging {
 
     func logInfo(_ message: @autoclosure () -> String, file: StaticString, function: StaticString, line: UInt) {
         onInfo(message())
+    }
+
+    func logDefault(_ message: @autoclosure () -> String, file: StaticString, function: StaticString, line: UInt) {
+        onDefault(message())
     }
 
     func logError(_ message: @autoclosure () -> String, file: StaticString, function: StaticString, line: UInt) {

--- a/Tests/BlueTriangleTests/Mocks/Mock.swift
+++ b/Tests/BlueTriangleTests/Mocks/Mock.swift
@@ -238,12 +238,12 @@ extension Mock {
         performanceReport: nil)
 
     static var performanceReport = PerformanceReport(
-        minCPU: 0.0,
-        maxCPU: 0.0,
-        avgCPU: 0.0,
-        minMemory: 0,
-        maxMemory: 0,
-        avgMemory: 0)
+        minCPU: 1.0,
+        maxCPU: 100.0,
+        avgCPU: 50.0,
+        minMemory: 10000000,
+        maxMemory: 100000000,
+        avgMemory: 50000000)
 
     static let capturedRequestURLString = "https://d33wubrfki0l68.cloudfront.net/f50c058607f066d0231c1fe6753eac79f17ea447/e6748/static/logo-cw.f6eaf6dc.png"
 

--- a/Tests/BlueTriangleTests/TimerRequestBuilderTests.swift
+++ b/Tests/BlueTriangleTests/TimerRequestBuilderTests.swift
@@ -98,24 +98,18 @@ final class TimerRequestBuilderTests: XCTestCase {
     }
 
     func testMetricsExceedingSizeLimitDropped() throws {
-        let expectedLengthMessage = "Custom metrics length is 3000010 characters; exceeding 1024 results in data loss."
-        let expectedSizeMessage = "Custom metrics encoded size of 4 MB (4,000,016 bytes) exceeds limit of 3 MB (3,000,000 bytes); dropping from timer request."
+        let expectedMessage = "Custom metrics encoded size of 4 MB (4,000,016 bytes) exceeds limit of 3 MB (3,000,000 bytes); dropping from timer request."
         let expectedString = Mock.makeTimerRequestJSON(
             appVersion: Bundle.main.releaseVersionNumber ?? "0.0",
             os: Device.os,
             osVersion: Device.osVersion,
             sdkVersion: Version.number)
 
-        var lengthMessage: String?
-        var sizeMessage: String?
+        var errorMessage: String?
         let errorExpectation = expectation(description: "Error logged")
         let logger = LoggerMock(onError: { message in
-            if lengthMessage == nil {
-                lengthMessage = message
-            } else {
-                sizeMessage = message
-                errorExpectation.fulfill()
-            }
+            errorMessage = message
+            errorExpectation.fulfill()
         })
 
         let sut = TimerRequestBuilder.live(logger: logger)
@@ -126,7 +120,6 @@ final class TimerRequestBuilderTests: XCTestCase {
         wait(for: [errorExpectation], timeout: 0.1)
 
         XCTAssertEqual(String(decoding: actualBody, as: UTF8.self), expectedString)
-        XCTAssertEqual(lengthMessage, expectedLengthMessage)
-        XCTAssertEqual(sizeMessage, expectedSizeMessage)
+        XCTAssertEqual(errorMessage, expectedMessage)
     }
 }

--- a/Tests/BlueTriangleTests/TimerRequestBuilderTests.swift
+++ b/Tests/BlueTriangleTests/TimerRequestBuilderTests.swift
@@ -1,0 +1,132 @@
+//
+//  TimerRequestBuilderTests.swift
+//
+//  Created by Mathew Gacy on 2/17/23.
+//  Copyright © 2023 Blue Triangle. All rights reserved.
+//
+
+import XCTest
+@testable import BlueTriangle
+
+final class TimerRequestBuilderTests: XCTestCase {
+    var timer: BTTimer {
+        var timeIntervals: [TimeInterval] = [
+            2000,
+            1000,
+            0
+        ]
+
+        let timer = BTTimer(
+            page: Mock.page,
+            logger: LoggerMock(),
+            intervalProvider: { timeIntervals.popLast() ?? 0 },
+            performanceMonitor: PerformanceMonitorMock())
+
+        timer.start()
+        timer.markInteractive()
+        timer.end()
+
+        return timer
+    }
+
+    func testBuildRequest() throws {
+        let expectedString = Mock.makeTimerRequestJSON(
+            appVersion: Bundle.main.releaseVersionNumber ?? "0.0",
+            os: Device.os,
+            osVersion: Device.osVersion,
+            sdkVersion: Version.number)
+
+        let errorExpectation = expectation(description: "Unexpected error logged")
+        errorExpectation.isInverted = true
+        let logger = LoggerMock(onError: { _ in
+                errorExpectation.fulfill()
+        })
+
+        let sut = TimerRequestBuilder.live(logger: logger)
+
+        let actualBody = try sut.builder(Mock.session, timer, nil).body!
+        wait(for: [errorExpectation], timeout: 0.1)
+
+        XCTAssertEqual(String(decoding: actualBody, as: UTF8.self), expectedString)
+    }
+
+    func testMetrics() throws {
+        let expectedKeyValue = "value"
+
+        let errorExpectation = expectation(description: "Unexpected error logged")
+        errorExpectation.isInverted = true
+        let logger = LoggerMock(onError: { _ in
+                errorExpectation.fulfill()
+        })
+
+        let sut = TimerRequestBuilder.live(logger: logger)
+
+        var session = Mock.session
+        session.metrics = ["key": .string(expectedKeyValue)]
+        let actualBody = try sut.builder(session, timer, nil).body!
+        wait(for: [errorExpectation], timeout: 0.1)
+
+        let jsonObject = try JSONSerialization.jsonObject(with: actualBody) as! [String: Any]
+        let actualMetrics = jsonObject["ECV"] as! [String: String]
+
+        XCTAssertEqual(actualMetrics, ["key": expectedKeyValue])
+    }
+
+    func testMetricsExceedingLengthLimitLogged() throws {
+        let expectedMessage = "Custom metrics length is 2010 characters; exceeding 1024 results in data loss."
+        let expectedKeyValue = String(repeating: "a", count: 2_000)
+
+        var errorMessage: String?
+        let errorExpectation = expectation(description: "Error logged")
+        let logger = LoggerMock(onError: { message in
+            errorMessage = message
+            errorExpectation.fulfill()
+        })
+
+        let sut = TimerRequestBuilder.live(logger: logger)
+
+        var session = Mock.session
+        session.metrics = ["key": .string(expectedKeyValue)]
+        let actualBody = try sut.builder(session, timer, nil).body!
+        wait(for: [errorExpectation], timeout: 0.1)
+
+        let jsonObject = try JSONSerialization.jsonObject(with: actualBody) as! [String: Any]
+        let actualMetrics = jsonObject["ECV"] as! [String: String]
+
+        XCTAssertEqual(actualMetrics, ["key": expectedKeyValue])
+        XCTAssertEqual(errorMessage, expectedMessage)
+    }
+
+    func testMetricsExceedingSizeLimitDropped() throws {
+        let expectedLengthMessage = "Custom metrics length is 3000010 characters; exceeding 1024 results in data loss."
+        let expectedSizeMessage = "Custom metrics encoded size of 4 MB (4,000,016 bytes) exceeds limit of 3 MB (3,000,000 bytes); dropping from timer request."
+        let expectedString = Mock.makeTimerRequestJSON(
+            appVersion: Bundle.main.releaseVersionNumber ?? "0.0",
+            os: Device.os,
+            osVersion: Device.osVersion,
+            sdkVersion: Version.number)
+
+        var lengthMessage: String?
+        var sizeMessage: String?
+        let errorExpectation = expectation(description: "Error logged")
+        let logger = LoggerMock(onError: { message in
+            if lengthMessage == nil {
+                lengthMessage = message
+            } else {
+                sizeMessage = message
+                errorExpectation.fulfill()
+            }
+        })
+
+        let sut = TimerRequestBuilder.live(logger: logger)
+
+        var session = Mock.session
+        session.metrics = ["key": .string(String(repeating: "a", count: 3_000_000))]
+        let actualBody = try sut.builder(session, timer, nil).body!
+        wait(for: [errorExpectation], timeout: 0.1)
+
+        XCTAssertEqual(String(decoding: actualBody, as: UTF8.self), expectedString)
+        XCTAssertEqual(lengthMessage, expectedLengthMessage)
+        XCTAssertEqual(sizeMessage, expectedSizeMessage)
+    }
+}

--- a/Tests/BlueTriangleTests/UploaderTests.swift
+++ b/Tests/BlueTriangleTests/UploaderTests.swift
@@ -242,7 +242,6 @@ final class UploaderTests: XCTestCase {
         }
 
         group.notify(queue: .main) {
-            print("SubscriptionCount: \(uploader.subscriptionCount) - RequestCount: \(currentRequestCount) - ResponseCount: \(responseCount)")
             XCTAssert(uploader.subscriptionCount > requestCount)
         }
 
@@ -254,6 +253,6 @@ final class UploaderTests: XCTestCase {
         otherExpectation.isInverted = true
         wait(for: [otherExpectation], timeout: 3.0)
 
-        XCTAssert(uploader.subscriptionCount < 3)
+        XCTAssert(uploader.subscriptionCount < 3, "Subscription count is \(uploader.subscriptionCount)")
     }
 }

--- a/Tests/BlueTriangleTests/UtilityTests.swift
+++ b/Tests/BlueTriangleTests/UtilityTests.swift
@@ -42,3 +42,36 @@ extension UtilityTests {
         XCTAssertEqual(nsNumber.numberType(), .int(Int(int64)))
     }
 }
+
+// MARK: - Data Manipulation
+extension UtilityTests {
+    var jsonObject1: Data {
+        .init("{\"a\":\"b\"}".utf8)
+    }
+
+    var jsonObject2: Data {
+        .init("{\"c\":\"d\"}".utf8)
+    }
+
+    var jsonArrayData: Data {
+        .init("[\"e\",\"f\"]".utf8)
+    }
+
+    func testAppendToInvalidObjectThrows() throws {
+        var sut = jsonArrayData
+        XCTAssertThrowsError(try sut.append(objectData: jsonObject1, key: "key"))
+    }
+
+    func testAppendObjectData() throws {
+        let addedKey = "added"
+
+        let expectedData = Data("""
+        {"a":"b","\(addedKey)":{"c":"d"}}
+        """.utf8)
+
+        var sut = jsonObject1
+        try sut.append(objectData: jsonObject2, key: addedKey)
+
+        XCTAssertEqual(sut, expectedData)
+    }
+}


### PR DESCRIPTION
Updates `TimerRequestBuilder` to add custom metrics to the `body` of `Request`s created for timers. Since we need to encode the metrics first to get their size before deciding to include them in the timer request I am adding the encoded metrics to the encoded `TimerRequest` data rather than adding a metrics member to the `TimerRequest` model itself. The latter approach would effectively require encoding the metrics twice. In benchmarks this averaged 0.151 seconds when the base64-encoded metrics size is just under the limit vs. 0.097 seconds with the current implementation.

The basic process is:

1. Encode the `TimerRequest` model
2. Encode the custom metrics (which is `[String: AnyCodable]`)
3. Check the size of the metrics data when base64 encoded (since 3MB of data grows to 4 MB with base64, for example). If that size is below the threshold, add the metrics data to the timer request data

This also adds support for logging messages with an `OSLogType.default` level (which is used when custom metrics exceed the length or size limits).