### PR TITLE
Add Custom Metrics Members

### DIFF
--- a/.swiftpm/xcode/xcshareddata/xcschemes/blue-triangle.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/blue-triangle.xcscheme
@@ -54,7 +54,18 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES">
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      codeCoverageEnabled = "YES"
+      onlyGenerateCoverageForSpecifiedTargets = "YES">
+      <CodeCoverageTargets>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "BlueTriangle"
+            BuildableName = "BlueTriangle"
+            BlueprintName = "BlueTriangle"
+            ReferencedContainer = "container:">
+         </BuildableReference>
+      </CodeCoverageTargets>
       <Testables>
          <TestableReference
             skipped = "NO">

--- a/Sources/BlueTriangle/BlueTriangle.swift
+++ b/Sources/BlueTriangle/BlueTriangle.swift
@@ -246,9 +246,9 @@ extension BlueTriangle {
 public extension BlueTriangle {
     /// Creates a timer timer to measure the duration of a user interaction.
     ///
-    /// The returned timer is not running. Call `start()` before passing to `endTimer(_:purchaseConfirmation:)`.
+    /// The returned timer is not running. Call ``BTTimer/start()`` before passing to ``endTimer(_:purchaseConfirmation:)``.
     ///
-    /// - note: `configure(_:)` must be called before attempting to create a timer.
+    /// - note: ``configure(_:)`` must be called before attempting to create a timer.
     ///
     /// - Parameters:
     ///   - page: An object providing information about the user interaction being timed.
@@ -265,7 +265,7 @@ public extension BlueTriangle {
 
     /// Creates a running timer to measure the duration of a user interaction.
     ///
-    /// - note: `configure(_:)` must be called before attempting to start a timer.
+    /// - note: ``configure(_:)`` must be called before attempting to start a timer.
     ///
     /// - Parameters:
     ///   - page: An object providing information about the user interaction being timed.

--- a/Sources/BlueTriangle/BlueTriangle.swift
+++ b/Sources/BlueTriangle/BlueTriangle.swift
@@ -352,7 +352,8 @@ public extension BlueTriangle {
     /// Updates the value stored in custom metrics for the given key, or adds a new key-value pair
     /// if the key does not exist.
     ///
-    /// Prefer this method over `setMetrics:forKey:` when using `NSNumber` values.
+    /// Prefer this method over `setMetrics:forKey:` when using `NSNumber` values to ensure that values are
+    /// handled properly.
     ///
     /// > Note: this member is provided for Objective-C compatibility; ``BlueTriangle/BlueTriangle/metrics``
     /// should be used when calling from Swift.
@@ -378,6 +379,10 @@ public extension BlueTriangle {
     }
 
     /// Returns the value associated with the given key if one exists.
+    ///
+    /// > Note: this member is provided for Objective-C compatibility; ``BlueTriangle/BlueTriangle/metrics``
+    /// should be used when calling from Swift.
+    ///
     /// - Parameter key: The key to look up in custom metrics.
     /// - Returns: The value associated with `key` in custom metrics or `nil` if none exists.
     @objc(getMetricsForKey:)

--- a/Sources/BlueTriangle/BlueTriangle.swift
+++ b/Sources/BlueTriangle/BlueTriangle.swift
@@ -311,6 +311,8 @@ public extension BlueTriangle {
     ///     dictionary, the `(key, value)` pair is added.
     private static func set(_ value: AnyCodable?, key: String) {
         lock.lock()
+        defer { lock.unlock() }
+
         if session.metrics != nil {
             session.metrics![key] = value
         } else {
@@ -319,7 +321,6 @@ public extension BlueTriangle {
             }
             session.metrics = [key: value]
         }
-        lock.unlock()
     }
 
     /// Updates the value stored in custom metrics for the given key, or adds a new key-value pair
@@ -337,9 +338,7 @@ public extension BlueTriangle {
     static func _setMetrics(_ value: Any?, forKey key: String) {
         switch value {
         case .none:
-            lock.lock()
-            session.metrics?[key] = nil
-            lock.unlock()
+            set(nil, key: key)
         case .some(let wrapped):
             do {
                 let value = try AnyCodable(wrapped)
@@ -367,9 +366,7 @@ public extension BlueTriangle {
     static func _setMetrics(nsNumber: NSNumber?, forKey key: String) {
         switch nsNumber {
         case .none:
-            lock.lock()
-            session.metrics?[key] = nil
-            lock.unlock()
+            set(nil, key: key)
         case .some(let wrapped):
             do {
                 let value = try AnyCodable(wrapped)

--- a/Sources/BlueTriangle/BlueTriangle.swift
+++ b/Sources/BlueTriangle/BlueTriangle.swift
@@ -167,6 +167,35 @@ final public class BlueTriangle: NSObject {
             lock.sync { session.trafficSegmentName = newValue }
         }
     }
+
+    /// Custom metrics.
+    public static var metrics: [String: AnyCodable]? {
+        get {
+            lock.sync { session.metrics }
+        }
+        set {
+            lock.sync { session.metrics = newValue }
+        }
+    }
+
+    /// Custom metrics.
+    ///
+    /// > Note: this member is provided for Objective-C compatibility; ``BlueTriangle/BlueTriangle/metrics``
+    /// should be used when calling from Swift.
+    @objc(metrics) public static var _metrics: [String: Any]? {
+        get {
+            lock.sync { session.metrics?.anyValues }
+        }
+        set {
+            do {
+                let converted = try newValue?.compactMapValues(AnyCodable.init)
+                print("newValue: \(newValue) - converted: \(converted)")
+                lock.sync { session.metrics = converted }
+            } catch {
+                logger.error(error.localizedDescription)
+            }
+        }
+    }
 }
 
 // MARK: - Configuration

--- a/Sources/BlueTriangle/BlueTriangle.swift
+++ b/Sources/BlueTriangle/BlueTriangle.swift
@@ -183,18 +183,7 @@ final public class BlueTriangle: NSObject {
     /// > Note: this member is provided for Objective-C compatibility; ``BlueTriangle/BlueTriangle/metrics``
     /// should be used when calling from Swift.
     @objc(metrics) public static var _metrics: [String: Any]? {
-        get {
-            lock.sync { session.metrics?.anyValues }
-        }
-        set {
-            do {
-                let converted = try newValue?.compactMapValues(AnyCodable.init)
-                print("newValue: \(newValue) - converted: \(converted)")
-                lock.sync { session.metrics = converted }
-            } catch {
-                logger.error(error.localizedDescription)
-            }
-        }
+        lock.sync { session.metrics?.anyValues }
     }
 }
 

--- a/Sources/BlueTriangle/Models/AnyCodable.swift
+++ b/Sources/BlueTriangle/Models/AnyCodable.swift
@@ -160,10 +160,10 @@ public enum AnyCodable: Codable, Equatable, Hashable {
 // MARK: - Associated Value Access
 public extension AnyCodable {
     /// The type-erased wrapped value.
-    var anyValue: Any? {
+    var anyValue: Any {
         switch self {
         case .none:
-            return nil
+            return Optional<Any>.none as Any
         case .bool(let bool):
             return bool as Any
         case .double(let double):

--- a/Sources/BlueTriangle/Models/AnyCodable.swift
+++ b/Sources/BlueTriangle/Models/AnyCodable.swift
@@ -322,6 +322,18 @@ extension AnyCodable: ExpressibleByStringLiteral {
     public init(stringLiteral value: String) {
         self = .string(value)
     }
+
+    /// Creates an instance initialized to the given value.
+    /// - Parameter value: The value of the new instance.
+    public init(unicodeScalarLiteral value: String) {
+        self = .string(value)
+    }
+
+    /// Creates an instance initialized to the given value.
+    /// - Parameter value: The value of the new instance.
+    public init(extendedGraphemeClusterLiteral value: String) {
+        self = .string(value)
+    }
 }
 
 extension AnyCodable: ExpressibleByStringInterpolation {}

--- a/Sources/BlueTriangle/Models/AnyCodable.swift
+++ b/Sources/BlueTriangle/Models/AnyCodable.swift
@@ -337,3 +337,11 @@ extension AnyCodable: ExpressibleByStringLiteral {
 }
 
 extension AnyCodable: ExpressibleByStringInterpolation {}
+
+// MARK: - Dictionary+Utils
+public extension Dictionary where Value == AnyCodable {
+    /// A dictionary containing the underlying values that were wrapped in ``AnyCodable``.
+    var anyValues: [Key: Any] {
+        mapValues { $0.anyValue }
+    }
+}

--- a/Tests/BlueTriangleTests/AnyCodableTests.swift
+++ b/Tests/BlueTriangleTests/AnyCodableTests.swift
@@ -144,9 +144,14 @@ extension AnyCodableTests {
     }
 
     func testUInt64Coding() throws {
-        let expectedValue: UInt64 = UInt64.max
-        let actualValue: UInt64? = try encodeAndDecode(expectedValue)
-        XCTAssertEqual(actualValue, expectedValue)
+        let expectedLargeValue: UInt64 = UInt64.max
+        let actualLargeValue: UInt64? = try encodeAndDecode(expectedLargeValue)
+        XCTAssertEqual(actualLargeValue, expectedLargeValue)
+
+        // Values within the range of possibile values of `Int64` will be decoded as such
+        let smallValue: UInt64 = 5
+        let actualSmallValue: UInt64? = try encodeAndDecode(smallValue)
+        XCTAssertNil(actualSmallValue)
     }
 
     func testURLCoding() throws {
@@ -344,5 +349,27 @@ extension AnyCodableTests {
         let sut = try AnyCodable(url)
         let actual = sut.anyValue as? URL
         XCTAssertEqual(actual, url)
+    }
+
+    func testAnyValueOfAnyCodableDictionary() throws {
+        let sut: [String: AnyCodable] = [
+            "string": "String",
+            "bool": true,
+            "double": 9.99,
+            "int": 9,
+            "array": ["a", "b", "c"],
+            "nested": [
+                "foo": "bar"
+            ]
+        ]
+
+        let actualValue = sut.anyValues
+
+        XCTAssertEqual(actualValue["string"] as? String, string)
+        XCTAssertEqual(actualValue["bool"] as? Bool, bool)
+        XCTAssertEqual(actualValue["double"] as? Double, double)
+        XCTAssertEqual(actualValue["int"] as? Int, int)
+        XCTAssertEqual(actualValue["array"] as? [String], ["a", "b", "c"])
+        XCTAssertEqual(actualValue["nested"] as? [String: String], ["foo": "bar"])
     }
 }

--- a/Tests/BlueTriangleTests/BlueTriangleTests.swift
+++ b/Tests/BlueTriangleTests/BlueTriangleTests.swift
@@ -468,6 +468,16 @@ extension BlueTriangleTests {
         XCTAssertNil(BlueTriangle.metrics)
     }
 
+    func testSetNilNSNumber() {
+        let key = "key"
+
+        BlueTriangle.reconfigure(session: Mock.session)
+
+        BlueTriangle._setMetrics(nsNumber: nil, forKey: key)
+
+        XCTAssertNil(BlueTriangle.metrics)
+    }
+
     func testSetNSNumber() {
         let key = "key"
         let double = 9.99

--- a/Tests/ObjcCompatibilityTests/ObjcCompatibilityTests.m
+++ b/Tests/ObjcCompatibilityTests/ObjcCompatibilityTests.m
@@ -79,6 +79,25 @@
     NSMutableURLRequest *urlRequest = [[NSMutableURLRequest alloc] initWithURL:url];
     [urlRequest setHTTPMethod:@"GET"];
     NSURLSessionDataTask *taskWithRequest = [session btDataTaskWithRequest:urlRequest completionHandler:^(NSData *data, NSURLResponse *response, NSError *error){}];
-}
 
+    // Custom metrics
+    NSNumber *expectedNumber = [NSNumber numberWithDouble:9.99];
+    NSString *numberKey = @"number";
+
+    NSString *expectedString = @"string_value";
+    NSString *stringKey = @"string";
+
+    [BlueTriangle setMetricsWithNsNumber:expectedNumber forKey:numberKey];
+    [BlueTriangle setMetrics:expectedString forKey:stringKey];
+
+    NSNumber *actualNumber = [BlueTriangle getMetricsForKey:numberKey];
+    XCTAssertEqual(actualNumber.doubleValue, expectedNumber.doubleValue);
+
+    NSString *actualString = [BlueTriangle getMetricsForKey:stringKey];
+    XCTAssertEqual(actualString, expectedString);
+
+    [BlueTriangle clearMetrics];
+    NSDictionary *actualMetrics = BlueTriangle.metrics;
+    XCTAssertNil(actualMetrics);
+}
 @end


### PR DESCRIPTION
Adds `BlueTriangle` methods to get and set custom metrics data.

When using Swift, metrics are accessed via `BlueTriangle.metrics`:

```swift
let currentMetrics = BlueTriangle.metrics // ["double": 9.99, "nested": ["foo": "bar"]]
BlueTriangle.metrics?["nested"] = ["new": "value"]
```

When using Objective-C they are accessed via `setMetrics:forKey:` and `getMetricsForKey:`:

```
[BlueTriangle setMetrics:expectedString forKey:stringKey];
NSString *actualString = [BlueTriangle getMetricsForKey:stringKey];
```

I also made `AnyCodable.anyValue` non-optional and added `Dictionary<Key, AnyCodable>.anyValues`. 

Finally, I threw in a couple small Swift-Flavored Markdown fixes and enabled gathering test coverage.