### PR TITLE
Improve  Ergonomics of Custom Metrics

### DIFF
--- a/Sources/BlueTriangle/BlueTriangle.swift
+++ b/Sources/BlueTriangle/BlueTriangle.swift
@@ -169,12 +169,12 @@ final public class BlueTriangle: NSObject {
     }
 
     /// Custom metrics.
-    public static var metrics: [String: AnyCodable]? {
+    public static var metrics: [String: AnyCodable] {
         get {
-            lock.sync { session.metrics }
+            lock.sync { session.metrics ?? [:] }
         }
         set {
-            lock.sync { session.metrics = newValue }
+            lock.sync { session.metrics = (newValue.isEmpty ? nil : newValue) }
         }
     }
 

--- a/Sources/BlueTriangle/Models/AnyCodable.swift
+++ b/Sources/BlueTriangle/Models/AnyCodable.swift
@@ -344,4 +344,155 @@ public extension Dictionary where Value == AnyCodable {
     var anyValues: [Key: Any] {
         mapValues { $0.anyValue }
     }
+
+    /// Accesses the array associated with the given key for reading and writing.
+    subscript(array key: Key) -> [AnyCodable]? {
+        get {
+            self[key]?.arrayValue
+        }
+        set {
+            switch newValue {
+            case .some(let wrapped):
+                self[key] = AnyCodable.array(wrapped)
+            case .none:
+                self[key] = nil
+            }
+        }
+    }
+
+    /// Accesses the Boolean associated with the given key for reading and writing.
+    subscript(bool key: Key) -> Bool? {
+        get {
+            self[key]?.boolValue
+        }
+        set {
+            switch newValue {
+            case .some(let wrapped):
+                self[key] = AnyCodable.bool(wrapped)
+            case .none:
+                self[key] = nil
+            }
+        }
+    }
+
+    /// Accesses the date associated with the given key for reading and writing.
+    subscript(date key: Key) -> Date? {
+        get {
+            self[key]?.dateValue
+        }
+        set {
+            switch newValue {
+            case .some(let wrapped):
+                self[key] = AnyCodable.date(wrapped)
+            case .none:
+                self[key] = nil
+            }
+        }
+    }
+
+    /// Accesses the dictionary associated with the given key for reading and writing.
+    subscript(dictionary key: Key) -> [String: AnyCodable]? {
+        get {
+            self[key]?.dictionaryValue
+        }
+        set {
+            switch newValue {
+            case .some(let wrapped):
+                self[key] = AnyCodable.dictionary(wrapped)
+            case .none:
+                self[key] = nil
+            }
+        }
+    }
+
+    /// Accesses the double associated with the given key for reading and writing.
+    subscript(double key: Key) -> Double? {
+        get {
+            self[key]?.doubleValue
+        }
+        set {
+            switch newValue {
+            case .some(let wrapped):
+                self[key] = AnyCodable.double(wrapped)
+            case .none:
+                self[key] = nil
+            }
+        }
+    }
+
+    /// Accesses the integer associated with the given key for reading and writing.
+    subscript(int key: Key) -> Int? {
+        get {
+            self[key]?.intValue
+        }
+        set {
+            switch newValue {
+            case .some(let wrapped):
+                self[key] = AnyCodable.int(wrapped)
+            case .none:
+                self[key] = nil
+            }
+        }
+    }
+
+    /// Accesses the 64-bit signed integer associated with the given key for reading and writing.
+    subscript(int64 key: Key) -> Int64? {
+        get {
+            self[key]?.int64Value
+        }
+        set {
+            switch newValue {
+            case .some(let wrapped):
+                self[key] = AnyCodable.int64(wrapped)
+            case .none:
+                self[key] = nil
+            }
+        }
+    }
+
+    /// Accesses the string associated with the given key for reading and writing.
+    subscript(string key: Key) -> String? {
+        get {
+            self[key]?.stringValue
+        }
+        set {
+            switch newValue {
+            case .some(let wrapped):
+                self[key] = AnyCodable.string(wrapped)
+            case .none:
+                self[key] = nil
+            }
+        }
+    }
+
+    /// Accesses the 64-bit unsigned integer associated with the given key for reading and writing.
+    subscript(uint64 key: Key) -> UInt64? {
+        get {
+            self[key]?.uint64Value
+        }
+        set {
+            switch newValue {
+            case .some(let wrapped):
+                self[key] = AnyCodable.uint64(wrapped)
+            case .none:
+                self[key] = nil
+            }
+        }
+    }
+
+    /// Accesses the URL associated with the given key for reading and writing.
+    subscript(url key: Key) -> URL? {
+        get {
+            self[key]?.urlValue
+        }
+        set {
+            switch newValue {
+            case .some(let wrapped):
+                self[key] = AnyCodable.url(wrapped)
+            case .none:
+                self[key] = nil
+            }
+        }
+    }
+}
 }

--- a/Tests/BlueTriangleTests/AnyCodableTests.swift
+++ b/Tests/BlueTriangleTests/AnyCodableTests.swift
@@ -9,6 +9,7 @@
 import XCTest
 
 final class AnyCodableTests: XCTestCase {
+    let key = "key"
     let array: [String] = ["a", "b", "c"]
     let bool: Bool = true
     let date = Date(timeIntervalSince1970: 1670000000)
@@ -329,6 +330,239 @@ extension AnyCodableTests {
         let value = 4
         let sut: AnyCodable = "The value is \(value)"
         XCTAssertEqual(sut, .string("The value is 4"))
+    }
+}
+
+// MARK: - Subscripts
+extension AnyCodableTests {
+    func testGetArraySubscript() {
+        let expectedValue: [AnyCodable] = [.string("a"), .string("b"), .string("c")]
+
+        let sut: [String: AnyCodable] = [
+            key: .array(expectedValue),
+            "other": "another value"
+        ]
+
+        XCTAssertEqual(sut[array: key], expectedValue)
+    }
+
+    func testSetArraySubscript() {
+        let expectedValue: [AnyCodable] = [.string("a"), .string("b"), .string("c")]
+
+        var sut: [String: AnyCodable] = [:]
+
+        sut[array: key] = expectedValue
+        XCTAssertEqual(sut, [key: .array(expectedValue)])
+
+        sut[array: key] = nil
+        XCTAssertEqual(sut, [:])
+    }
+
+    func testGetBoolSubscript() {
+        let expectedValue = bool
+
+        let sut: [String: AnyCodable] = [
+            key: .bool(expectedValue),
+            "other": "another value"
+        ]
+
+        XCTAssertEqual(sut[bool: key], expectedValue)
+    }
+
+    func testSetBoolSubscript() {
+        let expectedValue = bool
+
+        var sut: [String: AnyCodable] = [:]
+
+        sut[bool: key] = expectedValue
+        XCTAssertEqual(sut, [key: .bool(expectedValue)])
+
+        sut[bool: key] = nil
+        XCTAssertEqual(sut, [:])
+    }
+
+    func testGetDateSubscript() {
+        let expectedValue = date
+
+        let sut: [String: AnyCodable] = [
+            key: .date(expectedValue),
+            "other": "another value"
+        ]
+
+        XCTAssertEqual(sut[date: key], expectedValue)
+    }
+
+    func testSetDateSubscript() {
+        let expectedValue = date
+
+        var sut: [String: AnyCodable] = [:]
+
+        sut[date: key] = expectedValue
+        XCTAssertEqual(sut, [key: .date(expectedValue)])
+
+        sut[date: key] = nil
+        XCTAssertEqual(sut, [:])
+    }
+
+    func testGetDictionarySubscript() {
+        let expectedValue: [AnyCodable] = [.string("a"), .string("b"), .string("c")]
+
+        let sut: [String: AnyCodable] = [
+            key: .array(expectedValue),
+            "other": "another value"
+        ]
+
+        XCTAssertEqual(sut[array: key], expectedValue)
+    }
+
+    func testSetDictionarySubscript() {
+        let expectedValue: [String: AnyCodable] = ["a": .string("a"), "b": .string("b"), "c": .string("c")]
+
+        var sut: [String: AnyCodable] = [:]
+
+        sut[dictionary: key] = expectedValue
+        XCTAssertEqual(sut, [key: .dictionary(expectedValue)])
+
+        sut[dictionary: key] = nil
+        XCTAssertEqual(sut, [:])
+    }
+
+    func testGetDoubleSubscript() {
+        let expectedValue = double
+
+        let sut: [String: AnyCodable] = [
+            key: .double(expectedValue),
+            "other": "another value"
+        ]
+
+        XCTAssertEqual(sut[double: key], expectedValue)
+    }
+
+    func testSetDoubleSubscript() {
+        let expectedValue = double
+
+        var sut: [String: AnyCodable] = [:]
+
+        sut[double: key] = expectedValue
+        XCTAssertEqual(sut, [key: .double(expectedValue)])
+
+        sut[double: key] = nil
+        XCTAssertEqual(sut, [:])
+    }
+
+    func testGetIntSubscript() {
+        let expectedValue = int
+
+        let sut: [String: AnyCodable] = [
+            key: .int(expectedValue),
+            "other": "another value"
+        ]
+
+        XCTAssertEqual(sut[int: key], expectedValue)
+    }
+
+    func testSetIntSubscript() {
+        let expectedValue = int
+
+        var sut: [String: AnyCodable] = [:]
+
+        sut[int: key] = expectedValue
+        XCTAssertEqual(sut, [key: .int(expectedValue)])
+
+        sut[int: key] = nil
+        XCTAssertEqual(sut, [:])
+    }
+
+    func testGetInt64Subscript() {
+        let expectedValue = int64
+
+        let sut: [String: AnyCodable] = [
+            key: .int64(expectedValue),
+            "other": "another value"
+        ]
+
+        XCTAssertEqual(sut[int64: key], expectedValue)
+    }
+
+    func testSetInt64Subscript() {
+        let expectedValue = int64
+
+        var sut: [String: AnyCodable] = [:]
+
+        sut[int64: key] = expectedValue
+        XCTAssertEqual(sut, [key: .int64(expectedValue)])
+
+        sut[int64: key] = nil
+        XCTAssertEqual(sut, [:])
+    }
+
+    func testGetStringSubscript() {
+        let expectedValue = string
+
+        let sut: [String: AnyCodable] = [
+            key: .string(expectedValue),
+            "other": "another value"
+        ]
+
+        XCTAssertEqual(sut[string: key], expectedValue)
+    }
+
+    func testSetStringSubscript() {
+        let expectedValue = string
+
+        var sut: [String: AnyCodable] = [:]
+
+        sut[string: key] = expectedValue
+        XCTAssertEqual(sut, [key: .string(expectedValue)])
+
+        sut[string: key] = nil
+        XCTAssertEqual(sut, [:])
+    }
+
+    func testGetUInt64Subscript() {
+        let expectedValue = uint64
+
+        let sut: [String: AnyCodable] = [
+            key: .uint64(expectedValue),
+            "other": "another value"
+        ]
+
+        XCTAssertEqual(sut[uint64: key], expectedValue)
+    }
+
+    func testSetUInt64Subscript() {
+        let expectedValue = uint64
+
+        var sut: [String: AnyCodable] = [:]
+
+        sut[uint64: key] = expectedValue
+        XCTAssertEqual(sut, [key: .uint64(expectedValue)])
+
+        sut[uint64: key] = nil
+        XCTAssertEqual(sut, [:])
+    }
+
+    func testGetURLSubscript() {
+        let expectedValue = url
+
+        let sut: [String: AnyCodable] = [
+            key: .url(expectedValue),
+            "other": "another value"
+        ]
+
+        XCTAssertEqual(sut[url: key], expectedValue)
+    }
+
+    func testSetURLSubscript() {
+        let expectedValue = url
+
+        var sut: [String: AnyCodable] = [:]
+
+        sut[url: key] = expectedValue
+        XCTAssertEqual(sut, [key: .url(expectedValue)])
+
+        sut[url: key] = nil
+        XCTAssertEqual(sut, [:])
     }
 }
 

--- a/Tests/BlueTriangleTests/BlueTriangleTests.swift
+++ b/Tests/BlueTriangleTests/BlueTriangleTests.swift
@@ -325,9 +325,9 @@ extension BlueTriangleTests {
         ]
         BlueTriangle.reconfigure(session: session)
 
-        BlueTriangle.metrics?["new"] = [1, 2, 3]
+        BlueTriangle.metrics["new"] = [1, 2, 3]
 
-        let actualMetrics = BlueTriangle.metrics!
+        let actualMetrics = BlueTriangle.metrics
         XCTAssertEqual(actualMetrics, expectedMetrics)
     }
 
@@ -347,9 +347,9 @@ extension BlueTriangleTests {
         ]
         BlueTriangle.reconfigure(session: session)
 
-        BlueTriangle.metrics?["nested"] = nil
+        BlueTriangle.metrics["nested"] = nil
 
-        let actualMetrics = BlueTriangle.metrics!
+        let actualMetrics = BlueTriangle.metrics
         XCTAssertEqual(actualMetrics, expectedMetrics)
     }
 
@@ -387,7 +387,7 @@ extension BlueTriangleTests {
             session: session
         )
 
-        BlueTriangle.metrics?["nested"] = [
+        BlueTriangle.metrics["nested"] = [
             "new": "value"
         ]
 
@@ -447,7 +447,7 @@ extension BlueTriangleTests {
 
         BlueTriangle._setMetrics(nil, forKey: key)
 
-        XCTAssertNil(BlueTriangle.metrics)
+        XCTAssertEqual(BlueTriangle.metrics, [:])
     }
 
     func testSetUnwrappableAnyValueHandled() {
@@ -465,7 +465,7 @@ extension BlueTriangleTests {
         BlueTriangle._setMetrics(Mock.session, forKey: "value")
 
         wait(for: [errorExpectation], timeout: 1.0)
-        XCTAssertNil(BlueTriangle.metrics)
+        XCTAssertEqual(BlueTriangle.metrics, [:])
     }
 
     func testSetNilNSNumber() {
@@ -475,7 +475,7 @@ extension BlueTriangleTests {
 
         BlueTriangle._setMetrics(nsNumber: nil, forKey: key)
 
-        XCTAssertNil(BlueTriangle.metrics)
+        XCTAssertEqual(BlueTriangle.metrics, [:])
     }
 
     func testSetNSNumber() {
@@ -509,7 +509,7 @@ extension BlueTriangleTests {
         BlueTriangle.reconfigure(session: session)
 
         BlueTriangle.clearMetrics()
-        XCTAssertNil(BlueTriangle.metrics)
+        XCTAssertEqual(BlueTriangle.metrics, [:])
     }
 }
 


### PR DESCRIPTION
Minor changes to the ergonomics of custom metrics to address annoyances that emerged when updating the demo app to use them.

- Makes `BlueTriangle.metrics` non-optional
- Adds type-specific subscripts for `Dictionary`s with `AnyCodable` values

After:

```swift
var productID = 1
...
BlueTriangle.metrics[int: "product_id"] = productID
...
let productID: Int? = BlueTriangle.metrics[int: "product_id"]
```

Before:

```swift
var productID = 1
...
BlueTriangle.metrics?["product_id"] = .int(productID)
...
let productID: Int? = BlueTriangle.metrics?["product_id"]?.intValue
```
