### PR TITLE
Save sessionID in CrashReport

### DIFF
--- a/Sources/BlueTriangle/CrashReportManager.swift
+++ b/Sources/BlueTriangle/CrashReportManager.swift
@@ -47,11 +47,15 @@ final class CrashReportManager: CrashReportManaging {
             return
         }
         do {
-            let timerRequest = try makeTimerRequest(session: session,
+            // Update session to use `sessionID` from when app crashed
+            var sessionCopy = session
+            sessionCopy.sessionID = crashReport.sessionID
+
+            let timerRequest = try makeTimerRequest(session: sessionCopy,
                                                     crashTime: crashReport.report.time)
             uploader.send(request: timerRequest)
 
-            let reportRequest = try makeCrashReportRequest(session: session,
+            let reportRequest = try makeCrashReportRequest(session: sessionCopy,
                                                            report: crashReport.report)
             uploader.send(request: reportRequest)
 

--- a/Sources/BlueTriangle/CrashReportPersistence.swift
+++ b/Sources/BlueTriangle/CrashReportPersistence.swift
@@ -22,12 +22,11 @@ struct CrashReportPersistence {
         persistence?.file.path ?? "MISSING"
     }
 
-    static func save(_ exception: NSException) {
-        let report = CrashReport(exception: exception)
+    static func save(_ crashReport: CrashReport) {
         do {
-            try persistence?.save(report)
+            try persistence?.save(crashReport)
         } catch {
-            logger.error("Error saving \(report) to \(path): \(error.localizedDescription)")
+            logger.error("Error saving \(crashReport) to \(path): \(error.localizedDescription)")
         }
     }
 

--- a/Sources/BlueTriangle/Models/CrashReport.swift
+++ b/Sources/BlueTriangle/Models/CrashReport.swift
@@ -8,39 +8,45 @@
 import Foundation
 
 struct CrashReport: Codable {
-    let message: String
-    let eCnt: Int
-    let eTp: String
-    let ver: String
-    let appName: String
-    let line: Int
-    let column: Int
-    let time: Millisecond
 
-    enum CodingKeys: String, CodingKey {
-        case message = "msg"
-        case eCnt
-        case eTp
-        case ver = "VER"
-        case appName = "url"
-        case line
-        case column = "col"
-        case time
+    struct Report: Codable {
+        let message: String
+        let eCnt: Int
+        let eTp: String
+        let ver: String
+        let appName: String
+        let line: Int
+        let column: Int
+        let time: Millisecond
+
+        enum CodingKeys: String, CodingKey {
+            case message = "msg"
+            case eCnt
+            case eTp
+            case ver = "VER"
+            case appName = "url"
+            case line
+            case column = "col"
+            case time
+        }
     }
-}
 
-extension CrashReport {
+    let sessionID: Identifier
+    let report: Report
+
     init(
+        sessionID: Identifier,
         exception: NSException,
         intervalProvider: @escaping () -> TimeInterval = { Date().timeIntervalSince1970 }
     ) {
-        self.message = exception.bttCrashReportMessage
-        self.eCnt = 1
-        self.eTp = Constants.eTp
-        self.ver = Version.number
-        self.appName = Bundle.main.appName ?? "Unknown"
-        self.line = 1
-        self.column = 1
-        self.time = intervalProvider().milliseconds
+        self.sessionID = sessionID
+        self.report = Report(message: exception.bttCrashReportMessage,
+                           eCnt: 1,
+                           eTp: Constants.eTp,
+                           ver: Version.number,
+                           appName: Bundle.main.appName ?? "Unknown",
+                           line: 1,
+                           column: 1,
+                           time: intervalProvider().milliseconds)
     }
 }


### PR DESCRIPTION
Fixes an error where crash reports were being sent with the ID of the session during which they are uploaded rather than the session during which they were created.