### PR TITLE
Fix Test Errors

### DIFF
--- a/Sources/BlueTriangle/TimerRequestBuilder.swift
+++ b/Sources/BlueTriangle/TimerRequestBuilder.swift
@@ -40,17 +40,18 @@ struct TimerRequestBuilder {
                 }
             }
 
-            let model = TimerRequest(session: session,
-                                     page: timer.page,
-                                     timer: timer.pageTimeInterval,
-                                     customMetrics: customMetrics,
-                                     purchaseConfirmation: purchase,
-                                     performanceReport: timer.performanceReport)
+            let body = try encoder.encode(
+                TimerRequest(session: session,
+                             page: timer.page,
+                             timer: timer.pageTimeInterval,
+                             customMetrics: customMetrics,
+                             purchaseConfirmation: purchase,
+                             performanceReport: timer.performanceReport))
 
-            return try Request(method: .post,
+            return Request(method: .post,
                            url: Constants.timerEndpoint,
                            headers: nil,
-                           model: model)
+                           body: body.base64EncodedData())
         }
     }
 }

--- a/Sources/BlueTriangle/TimerRequestBuilder.swift
+++ b/Sources/BlueTriangle/TimerRequestBuilder.swift
@@ -10,10 +10,8 @@ import Foundation
 struct TimerRequestBuilder {
     let builder: (Session, BTTimer, PurchaseConfirmation?) throws -> Request
 
-    static func live(logger: Logging) -> Self {
-        let encoder = JSONEncoder()
-
-        return .init { session, timer, purchase in
+    static func live(logger: Logging, encoder: JSONEncoder = .init()) -> Self {
+        .init { session, timer, purchase in
             var customMetrics: String? = nil
             if let metrics = session.metrics {
                 do {

--- a/Tests/BlueTriangleTests/TimerRequestBuilderTests.swift
+++ b/Tests/BlueTriangleTests/TimerRequestBuilderTests.swift
@@ -9,6 +9,12 @@ import XCTest
 @testable import BlueTriangle
 
 final class TimerRequestBuilderTests: XCTestCase {
+   var encoder: JSONEncoder = {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+        return encoder
+    }()
+
     var timer: BTTimer {
         var timeIntervals: [TimeInterval] = [
             2000,
@@ -42,7 +48,7 @@ final class TimerRequestBuilderTests: XCTestCase {
                 errorExpectation.fulfill()
         })
 
-        let sut = TimerRequestBuilder.live(logger: logger)
+        let sut = TimerRequestBuilder.live(logger: logger, encoder: encoder)
 
         let actualBody = try sut.builder(Mock.session, timer, nil).body!
         wait(for: [errorExpectation], timeout: 0.1)
@@ -63,7 +69,7 @@ final class TimerRequestBuilderTests: XCTestCase {
                 errorExpectation.fulfill()
         })
 
-        let sut = TimerRequestBuilder.live(logger: logger)
+        let sut = TimerRequestBuilder.live(logger: logger, encoder: encoder)
 
         var session = Mock.session
         session.metrics = [
@@ -102,7 +108,7 @@ final class TimerRequestBuilderTests: XCTestCase {
             logExpectation.fulfill()
         })
 
-        let sut = TimerRequestBuilder.live(logger: logger)
+        let sut = TimerRequestBuilder.live(logger: logger, encoder: encoder)
 
         var session = Mock.session
         session.metrics = ["key": .string(expectedKeyValue)]
@@ -131,7 +137,7 @@ final class TimerRequestBuilderTests: XCTestCase {
             logExpectation.fulfill()
         })
 
-        let sut = TimerRequestBuilder.live(logger: logger)
+        let sut = TimerRequestBuilder.live(logger: logger, encoder: encoder)
 
         var session = Mock.session
         session.metrics = ["key": .string(String(repeating: "a", count: 3_000_000))]

--- a/Tests/BlueTriangleTests/TimerRequestBuilderTests.swift
+++ b/Tests/BlueTriangleTests/TimerRequestBuilderTests.swift
@@ -63,6 +63,10 @@ final class TimerRequestBuilderTests: XCTestCase {
         let value4 = 0
         let value5 = 1188.2999999999884
 
+        let expectedMetrics = """
+        {"fifthVar":\(value5),"firstVar":"https:\\/\\/portal.bluetriangletech.com","fourthVar":\(value4),"secondVar":\(value2),"thirdVar":"\(value3)"}
+        """
+
         let errorExpectation = expectation(description: "Unexpected error logged")
         errorExpectation.isInverted = true
         let logger = LoggerMock(onError: { _ in
@@ -83,18 +87,10 @@ final class TimerRequestBuilderTests: XCTestCase {
         let actualBody = try sut.builder(session, timer, nil).body!
         wait(for: [errorExpectation], timeout: 0.1)
 
-        let jsonString = String(decoding: actualBody, as: UTF8.self)
         let jsonObject = try JSONSerialization.jsonObject(with: actualBody.base64DecodedData()!) as! [String: Any]
-
         let metricsString = jsonObject["ECV"] as! String
-        let metricsObject = try JSONSerialization.jsonObject(with: Data(metricsString.utf8)) as! [String: Any]
 
-        XCTAssertEqual(metricsObject.keys.count, 5)
-        XCTAssertEqual(metricsObject["firstVar"] as! String, value1)
-        XCTAssertEqual(metricsObject["secondVar"] as! Int, value2)
-        XCTAssertEqual(metricsObject["thirdVar"] as! String, value3)
-        XCTAssertEqual(metricsObject["fourthVar"] as! Int, value4)
-        XCTAssertEqual(metricsObject["fifthVar"] as! Double, value5)
+        XCTAssertEqual(metricsString, expectedMetrics)
     }
 
     func testMetricsExceedingLengthLimitLogged() throws {


### PR DESCRIPTION
Fixes test errors that appeared after merging the latest changes into the `intermediary/custom-metrics/main` branch.

Changes:

- Adds `encoder` parameter to `TimerRequestBuilder.live(logger:)` and uses that to also encode the `TimerRequest` instances it creates
- Updates `TimerRequestBuilderTests` methods to use an encoder with sorted keys
- Simplify `TimerRequestBuilderTests.testMetrics` by asserting on the metrics string now that the keys are sorted