### PR TITLE
Bugfix/page type issue (#22)

### DIFF
--- a/BlueTriangleSDK-Swift.podspec
+++ b/BlueTriangleSDK-Swift.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
     s.name             = 'BlueTriangleSDK-Swift'
-    s.version          = '3.9.1'
+    s.version          = '3.9.2'
     s.summary          = 'BlueTriangleSDK exposes methods to send analytics and crash data to the Blue Triangle portal'
     s.description      = <<-DESC
     BlueTriangleSDK exposes methods to send analytics and crash data to the Blue Triangle portal via HTTP Post

--- a/Sources/BlueTriangle/BTSignalCrashReporter.swift
+++ b/Sources/BlueTriangle/BTSignalCrashReporter.swift
@@ -106,7 +106,7 @@ exit value : \(crash.exit_value)
 // MARK: - Private
 private extension BTSignalCrashReporter {
     private  func makeTimerRequest(session: Session, report: ErrorReport, pageName : String?) throws -> Request {
-        let page = Page(pageName: pageName ?? Constants.crashID, pageType: Device.name)
+        let page = Page(pageName: pageName ?? Constants.crashID, pageType: "")
         let timer = PageTimeInterval(startTime: report.time, interactiveTime: 0, pageTime: Constants.minPgTm)
         let nativeProperty =  report.nativeApp.copy(.Regular)
         let model = TimerRequest(session: session,
@@ -131,7 +131,7 @@ private extension BTSignalCrashReporter {
             "txnName": session.trafficSegmentName,
             "sessionID": String(session.sessionID),
             "pgTm": "0",
-            "pageType": Device.name,
+            "pageType": "",
             "AB": session.abTestID,
             "DCTR": session.dataCenter,
             "CmpN": session.campaignName,

--- a/Sources/BlueTriangle/CrashReportManager.swift
+++ b/Sources/BlueTriangle/CrashReportManager.swift
@@ -82,7 +82,7 @@ final class CrashReportManager: CrashReportManaging {
 // MARK: - Private
 private extension CrashReportManager {
     func makeTimerRequest(session: Session, report: ErrorReport, pageName : String?) throws -> Request {
-        let page = Page(pageName: pageName ?? Constants.crashID, pageType: Device.name)
+        let page = Page(pageName: pageName ?? Constants.crashID, pageType: "")
         let timer = PageTimeInterval(startTime: report.time, interactiveTime: 0, pageTime: Constants.minPgTm)
         let nativeProperty =  report.nativeApp.copy(.Regular)
         let model = TimerRequest(session: session,
@@ -107,7 +107,7 @@ private extension CrashReportManager {
             "txnName": session.trafficSegmentName,
             "sessionID": String(session.sessionID),
             "pgTm": "0",
-            "pageType": Device.name,
+            "pageType": "",
             "AB": session.abTestID,
             "DCTR": session.dataCenter,
             "CmpN": session.campaignName,

--- a/Sources/BlueTriangle/Version.swift
+++ b/Sources/BlueTriangle/Version.swift
@@ -1,3 +1,3 @@
 enum Version {
-    static let number = "3.9.1"
+    static let number = "3.9.2"
 }

--- a/Sources/BlueTriangle/Vitals/ANR/ANRWatchDog.swift
+++ b/Sources/BlueTriangle/Vitals/ANR/ANRWatchDog.swift
@@ -132,7 +132,7 @@ An task blocking main thread since \(self.errorTriggerInterval) seconds
     }
     
     private func makeTimerRequest(session: Session, report: ErrorReport, pageName: String?) throws -> Request {
-        let page = Page(pageName: pageName ?? ANRWatchDog.TIMER_PAGE_NAME, pageType: Device.name)
+        let page = Page(pageName: pageName ?? ANRWatchDog.TIMER_PAGE_NAME, pageType: "")
         let timer = PageTimeInterval(startTime: report.time, interactiveTime: 0, pageTime: Constants.minPgTm)
         let nativeProperty = BlueTriangle.recentTimer()?.nativeAppProperties ?? .empty
         let model = TimerRequest(session: session,
@@ -157,7 +157,7 @@ An task blocking main thread since \(self.errorTriggerInterval) seconds
             "txnName": session.trafficSegmentName,
             "sessionID": String(session.sessionID),
             "pgTm": "0",
-            "pageType": Device.name,
+            "pageType": "",
             "AB": session.abTestID,
             "DCTR": session.dataCenter,
             "CmpN": session.campaignName,

--- a/Sources/BlueTriangle/Vitals/Memory/MemoryWarningWatchDog.swift
+++ b/Sources/BlueTriangle/Vitals/Memory/MemoryWarningWatchDog.swift
@@ -99,7 +99,7 @@ extension MemoryWarningWatchDog {
     }
     
     private func makeTimerRequest(session: Session, report: ErrorReport, pageName: String?) throws -> Request {
-        let page = Page(pageName: pageName ?? MemoryWarningWatchDog.DEFAULT_PAGE_NAME, pageType: Device.name)
+        let page = Page(pageName: pageName ?? MemoryWarningWatchDog.DEFAULT_PAGE_NAME, pageType: "")
         let timer = PageTimeInterval(startTime: report.time, interactiveTime: 0, pageTime: Constants.minPgTm)
         let nativeProperty = BlueTriangle.recentTimer()?.nativeAppProperties ?? .empty
         let model = TimerRequest(session: session,
@@ -124,7 +124,7 @@ extension MemoryWarningWatchDog {
             "txnName": session.trafficSegmentName,
             "sessionID": String(session.sessionID),
             "pgTm": "0",
-            "pageType": Device.name,
+            "pageType": "",
             "AB": session.abTestID,
             "DCTR": session.dataCenter,
             "CmpN": session.campaignName,


### PR DESCRIPTION
* Update tests.yml

added test run on iOS 17

* Update tests.yml

cmd syntax issue resolved

* Bugfix/remove exclude from launch time (#20)

* Remove exclude property from LaunchTime Payload

* Remove exclude property from LaunchTime Payload

* Added log to BTTWebViewTracker

* Updated sdk memory warning message

* Added verifySessionStitching method to BTTWebViewTracker

* Updated verifySessionStitching method to BTTWebViewTracker

* Added a DEBUG condition to the verifyStitchingSession function so that it is only applicable in debug mode.

* Added siteId verification on WebViewTracker

* Added siteId verification on WebViewTracker

* Updated Verify session stitching error message and ReadMe.

* Added trafficSegmentName field to BTTimer

---------



* Set pageType empty on exclude-20- and error.rcv requests

* update version

---------